### PR TITLE
Fix login not persisting across page refreshes

### DIFF
--- a/apps/client/src/views/MikotoClientProvider.tsx
+++ b/apps/client/src/views/MikotoClientProvider.tsx
@@ -50,7 +50,7 @@ export function MikotoClientProvider({
 
   useEffect(() => {
     if (!initialized.current) {
-      // initialized.current = true;
+      initialized.current = true;
 
       const mi = new MikotoClient({
         url: env.PUBLIC_SERVER_URL,

--- a/packages/mikoto.js/src/AuthClient.ts
+++ b/packages/mikoto.js/src/AuthClient.ts
@@ -20,6 +20,7 @@ export interface AuthClientOptions {
 export class AuthClient {
   api: Api;
   refreshToken?: string;
+  private setRefreshToken?: (token: string) => void;
 
   // this prevents multiple refresh calls from happening at the same time
   // when multiple requests are made in the same tick
@@ -30,6 +31,7 @@ export class AuthClient {
       });
       if (res.refreshToken) {
         this.refreshToken = res.refreshToken;
+        this.setRefreshToken?.(res.refreshToken);
       }
       return res.accessToken;
     },
@@ -43,6 +45,7 @@ export class AuthClient {
   constructor(options: AuthClientOptions) {
     this.api = createApiClient(options.url, {});
     this.refreshToken = options.refreshToken?.();
+    this.setRefreshToken = options.setRefreshToken;
   }
 
   async refresh(): Promise<string> {


### PR DESCRIPTION
## Summary

Fixes a bug where refreshing the page would immediately log the user out instead of restoring the session.

**Root causes:**
- The React Strict Mode initialization guard in `MikotoClientProvider` was commented out, causing double `MikotoClient` creation and race conditions during token refresh
- `AuthClient` accepted a `setRefreshToken` callback but never actually called it, so server-rotated refresh tokens were never persisted back to localStorage

## Test plan

- [ ] Log in, refresh the page — session should persist
- [ ] Verify no double-initialization in React Strict Mode (check console for duplicate connection logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)