### PR TITLE
Fix kick permission check in user context menu

### DIFF
--- a/apps/client/src/components/modals/ContextMenus.tsx
+++ b/apps/client/src/components/modals/ContextMenus.tsx
@@ -24,7 +24,9 @@ export function UserContextMenu({ user, member }: UserContextMenuProps) {
       >
         Profile
       </ContextMenu.Link>
-      {member && member.checkPermission(permissions.ban) && (
+      {member &&
+        member.space?.member?.userId !== member.userId &&
+        member.space?.member?.checkPermission(permissions.ban) && (
         <ContextMenu.Link
           onClick={async () => {
             await member.kick();

--- a/apps/superego/src/routes/spaces/members.rs
+++ b/apps/superego/src/routes/spaces/members.rs
@@ -145,6 +145,9 @@ async fn delete(
     Load(acting_member): Load<MemberExt>,
     Path((space_id, user_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<()>, Error> {
+    if acting_member.user.base.id == user_id {
+        return Err(Error::forbidden("You cannot ban yourself"));
+    }
     permissions_or_admin(&space, &acting_member, Permission::BAN)?;
 
     // ban user


### PR DESCRIPTION
## Summary

- Previously, the kick button visibility was checking the *target* member's ban permission instead of the *current* user's permission
- Also adds a self-kick guard so users don't see a kick option on their own context menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)