### PR TITLE
Separate kick and ban into distinct actions

### DIFF
--- a/apps/client/src/components/modals/ContextMenus.tsx
+++ b/apps/client/src/components/modals/ContextMenus.tsx
@@ -27,23 +27,23 @@ export function UserContextMenu({ user, member }: UserContextMenuProps) {
       {member &&
         member.space?.member?.userId !== member.userId &&
         member.space?.member?.checkPermission(permissions.ban) && (
-        <>
-          <ContextMenu.Link
-            onClick={async () => {
-              await member.kick();
-            }}
-          >
-            Kick {user.name}
-          </ContextMenu.Link>
-          <ContextMenu.Link
-            onClick={async () => {
-              await member.ban();
-            }}
-          >
-            Ban {user.name}
-          </ContextMenu.Link>
-        </>
-      )}
+          <>
+            <ContextMenu.Link
+              onClick={async () => {
+                await member.kick();
+              }}
+            >
+              Kick {user.name}
+            </ContextMenu.Link>
+            <ContextMenu.Link
+              onClick={async () => {
+                await member.ban();
+              }}
+            >
+              Ban {user.name}
+            </ContextMenu.Link>
+          </>
+        )}
     </ContextMenu>
   );
 }

--- a/apps/client/src/components/modals/ContextMenus.tsx
+++ b/apps/client/src/components/modals/ContextMenus.tsx
@@ -27,13 +27,22 @@ export function UserContextMenu({ user, member }: UserContextMenuProps) {
       {member &&
         member.space?.member?.userId !== member.userId &&
         member.space?.member?.checkPermission(permissions.ban) && (
-        <ContextMenu.Link
-          onClick={async () => {
-            await member.kick();
-          }}
-        >
-          Kick {user.name}
-        </ContextMenu.Link>
+        <>
+          <ContextMenu.Link
+            onClick={async () => {
+              await member.kick();
+            }}
+          >
+            Kick {user.name}
+          </ContextMenu.Link>
+          <ContextMenu.Link
+            onClick={async () => {
+              await member.ban();
+            }}
+          >
+            Ban {user.name}
+          </ContextMenu.Link>
+        </>
       )}
     </ContextMenu>
   );

--- a/apps/client/src/components/surfaces/BotSettingSurface.tsx
+++ b/apps/client/src/components/surfaces/BotSettingSurface.tsx
@@ -11,14 +11,19 @@ import {
   Textarea,
 } from '@chakra-ui/react';
 import styled from '@emotion/styled';
-import { faCopy, faPlus, faRobot, faTrash } from '@fortawesome/free-solid-svg-icons';
+import {
+  faCopy,
+  faPlus,
+  faRobot,
+  faTrash,
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { BotInfo, BotSpaceInfo } from '@mikoto-io/mikoto.js';
 import { useSetAtom } from 'jotai';
 import { useState } from 'react';
-import { useSnapshot } from 'valtio/react';
 import { useAsync } from 'react-async-hook';
 import { useForm } from 'react-hook-form';
+import { useSnapshot } from 'valtio/react';
 
 import { modalState } from '@/components/ContextMenu';
 import { Surface } from '@/components/Surface';

--- a/apps/superego/api.json
+++ b/apps/superego/api.json
@@ -1447,7 +1447,7 @@
         "tags": [
           "Members"
         ],
-        "summary": "Ban Member",
+        "summary": "Kick Member",
         "operationId": "members.delete",
         "responses": {
           "200": {
@@ -1613,6 +1613,80 @@
         }
       }
     },
+    "/spaces/{spaceId}/bans/": {
+      "get": {
+        "tags": [
+          "Bans"
+        ],
+        "summary": "List Bans",
+        "operationId": "bans.list",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BanInfo"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Bans"
+        ],
+        "summary": "Ban User",
+        "operationId": "bans.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BanCreatePayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BanInfo"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/spaces/{spaceId}/bans/{userId}": {
+      "delete": {
+        "tags": [
+          "Bans"
+        ],
+        "summary": "Unban User",
+        "operationId": "bans.delete",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "null"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/spaces/{spaceId}/invites/": {
       "get": {
         "tags": [
@@ -1690,6 +1764,62 @@
   },
   "components": {
     "schemas": {
+      "BanCreatePayload": {
+        "type": "object",
+        "required": [
+          "userId"
+        ],
+        "properties": {
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "BanInfo": {
+        "type": "object",
+        "required": [
+          "id",
+          "spaceId",
+          "userId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "spaceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/User"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
       "BotCreatedResponse": {
         "type": "object",
         "required": [

--- a/apps/superego/src/entities/ban.rs
+++ b/apps/superego/src/entities/ban.rs
@@ -45,9 +45,37 @@ impl Ban {
         Ok(ban)
     }
 
+    pub async fn list_by_space<'c, X: sqlx::PgExecutor<'c>>(
+        space_id: Uuid,
+        db: X,
+    ) -> Result<Vec<Self>, Error> {
+        let bans = sqlx::query_as(
+            r#"
+            SELECT * FROM "Ban" WHERE "spaceId" = $1
+            "#,
+        )
+        .bind(space_id)
+        .fetch_all(db)
+        .await?;
+        Ok(bans)
+    }
+
     pub async fn delete<'c, X: sqlx::PgExecutor<'c>>(id: Uuid, db: X) -> Result<(), Error> {
         sqlx::query(r#"DELETE FROM "Ban" WHERE "id" = $1"#)
             .bind(id)
+            .execute(db)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn delete_by_space_and_user<'c, X: sqlx::PgExecutor<'c>>(
+        space_id: Uuid,
+        user_id: Uuid,
+        db: X,
+    ) -> Result<(), Error> {
+        sqlx::query(r#"DELETE FROM "Ban" WHERE "spaceId" = $1 AND "userId" = $2"#)
+            .bind(space_id)
+            .bind(user_id)
             .execute(db)
             .await?;
         Ok(())

--- a/apps/superego/src/routes/bots.rs
+++ b/apps/superego/src/routes/bots.rs
@@ -14,7 +14,10 @@ use crate::{
         SpaceExt, SpaceUser, TokenPair, User, UserPatch,
     },
     error::Error,
-    functions::{jwt::{jwt_key, Claims}, pubsub::emit_event},
+    functions::{
+        jwt::{jwt_key, Claims},
+        pubsub::emit_event,
+    },
 };
 
 pub fn router() -> ApiRouter {
@@ -327,12 +330,7 @@ async fn remove_bot_from_space(
 
     SpaceUser::delete_by_key(&key, db()).await?;
 
-    emit_event(
-        "members.onDelete",
-        &member,
-        &format!("space:{space_id}"),
-    )
-    .await?;
+    emit_event("members.onDelete", &member, &format!("space:{space_id}")).await?;
     emit_event("spaces.onDelete", &space, &format!("user:{bot_id}")).await?;
 
     Ok(Json(()))

--- a/apps/superego/src/routes/mod.rs
+++ b/apps/superego/src/routes/mod.rs
@@ -91,6 +91,11 @@ fn build_app_router() -> AppRouter<State> {
         )
         .nest("roles", "/spaces/:spaceId/roles", spaces::roles::router())
         .nest(
+            "bans",
+            "/spaces/:spaceId/bans",
+            spaces::bans::router(),
+        )
+        .nest(
             "roles",
             "/spaces/:spaceId/invites",
             spaces::invites::router(),

--- a/apps/superego/src/routes/mod.rs
+++ b/apps/superego/src/routes/mod.rs
@@ -90,11 +90,7 @@ fn build_app_router() -> AppRouter<State> {
             spaces::members::router(),
         )
         .nest("roles", "/spaces/:spaceId/roles", spaces::roles::router())
-        .nest(
-            "bans",
-            "/spaces/:spaceId/bans",
-            spaces::bans::router(),
-        )
+        .nest("bans", "/spaces/:spaceId/bans", spaces::bans::router())
         .nest(
             "roles",
             "/spaces/:spaceId/invites",

--- a/apps/superego/src/routes/spaces/bans.rs
+++ b/apps/superego/src/routes/spaces/bans.rs
@@ -1,0 +1,144 @@
+use aide::axum::routing::{delete_with, get_with, post_with};
+use axum::{extract::Path, Json};
+use schemars::JsonSchema;
+use uuid::Uuid;
+
+use crate::{
+    db::db,
+    entities::{Ban, MemberExt, MemberKey, SpaceExt, SpaceUser, User},
+    error::Error,
+    functions::{
+        jwt::Claims,
+        permissions::{permissions_or_admin, Permission},
+        pubsub::emit_event,
+    },
+    middlewares::load::Load,
+    routes::{router::AppRouter, ws::state::State},
+};
+
+#[derive(Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct BanCreatePayload {
+    pub user_id: Uuid,
+    pub reason: Option<String>,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct BanInfo {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub space_id: Uuid,
+    pub reason: Option<String>,
+    pub user: Option<User>,
+}
+
+async fn list(
+    _claim: Claims,
+    Load(space): Load<SpaceExt>,
+    Load(acting_member): Load<MemberExt>,
+    Path(space_id): Path<Uuid>,
+) -> Result<Json<Vec<BanInfo>>, Error> {
+    permissions_or_admin(&space, &acting_member, Permission::BAN)?;
+
+    let bans = Ban::list_by_space(space_id, db()).await?;
+    let user_ids: Vec<Uuid> = bans.iter().map(|b| b.user_id).collect();
+    let user_map = User::dataload(user_ids, db()).await?;
+
+    let ban_infos: Vec<BanInfo> = bans
+        .into_iter()
+        .map(|b| BanInfo {
+            id: b.id,
+            user_id: b.user_id,
+            space_id: b.space_id,
+            reason: b.reason,
+            user: user_map.get(&b.user_id).cloned(),
+        })
+        .collect();
+
+    Ok(ban_infos.into())
+}
+
+async fn create(
+    _claim: Claims,
+    Load(space): Load<SpaceExt>,
+    Load(acting_member): Load<MemberExt>,
+    Path(space_id): Path<Uuid>,
+    Json(body): Json<BanCreatePayload>,
+) -> Result<Json<BanInfo>, Error> {
+    if acting_member.user.base.id == body.user_id {
+        return Err(Error::forbidden("You cannot ban yourself"));
+    }
+    permissions_or_admin(&space, &acting_member, Permission::BAN)?;
+
+    // Check if already banned
+    if Ban::find_by_space_and_user(space_id, body.user_id, db())
+        .await?
+        .is_some()
+    {
+        return Err(Error::forbidden("User is already banned from this space"));
+    }
+
+    // Create ban record
+    let ban = Ban {
+        id: Uuid::new_v4(),
+        user_id: body.user_id,
+        space_id,
+        reason: body.reason,
+    };
+    ban.create(db()).await?;
+
+    // Remove membership if the user is currently a member
+    let key = MemberKey::new(space_id, body.user_id);
+    if let Ok(member) = SpaceUser::get_by_key(&key, db()).await {
+        let member = MemberExt::dataload_one(member, db()).await?;
+        member.base.delete(db()).await?;
+        emit_event("members.onDelete", &member, &format!("space:{space_id}")).await?;
+    }
+
+    let user = User::find_by_id(body.user_id, db()).await.ok();
+
+    Ok(Json(BanInfo {
+        id: ban.id,
+        user_id: ban.user_id,
+        space_id: ban.space_id,
+        reason: ban.reason,
+        user,
+    }))
+}
+
+async fn delete(
+    _claim: Claims,
+    Load(space): Load<SpaceExt>,
+    Load(acting_member): Load<MemberExt>,
+    Path((space_id, user_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<()>, Error> {
+    permissions_or_admin(&space, &acting_member, Permission::BAN)?;
+
+    Ban::delete_by_space_and_user(space_id, user_id, db()).await?;
+    Ok(().into())
+}
+
+static TAG: &str = "Bans";
+
+pub fn router() -> AppRouter<State> {
+    AppRouter::new()
+        .route(
+            "/",
+            get_with(list, |o| {
+                o.tag(TAG).id("bans.list").summary("List Bans")
+            }),
+        )
+        .route(
+            "/",
+            post_with(create, |o| {
+                o.tag(TAG).id("bans.create").summary("Ban User")
+            }),
+        )
+        .route(
+            "/:userId",
+            delete_with(delete, |o| {
+                o.tag(TAG).id("bans.delete").summary("Unban User")
+            }),
+        )
+}

--- a/apps/superego/src/routes/spaces/bans.rs
+++ b/apps/superego/src/routes/spaces/bans.rs
@@ -125,15 +125,11 @@ pub fn router() -> AppRouter<State> {
     AppRouter::new()
         .route(
             "/",
-            get_with(list, |o| {
-                o.tag(TAG).id("bans.list").summary("List Bans")
-            }),
+            get_with(list, |o| o.tag(TAG).id("bans.list").summary("List Bans")),
         )
         .route(
             "/",
-            post_with(create, |o| {
-                o.tag(TAG).id("bans.create").summary("Ban User")
-            }),
+            post_with(create, |o| o.tag(TAG).id("bans.create").summary("Ban User")),
         )
         .route(
             "/:userId",

--- a/apps/superego/src/routes/spaces/members.rs
+++ b/apps/superego/src/routes/spaces/members.rs
@@ -146,18 +146,9 @@ async fn delete(
     Path((space_id, user_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<()>, Error> {
     if acting_member.user.base.id == user_id {
-        return Err(Error::forbidden("You cannot ban yourself"));
+        return Err(Error::forbidden("You cannot kick yourself"));
     }
     permissions_or_admin(&space, &acting_member, Permission::BAN)?;
-
-    // ban user
-    let ban = Ban {
-        id: Uuid::new_v4(),
-        user_id,
-        space_id,
-        reason: None,
-    };
-    ban.create(db()).await?;
 
     let key = MemberKey::new(space_id, user_id);
     let member = SpaceUser::get_by_key(&key, db()).await?;
@@ -202,7 +193,7 @@ pub fn router() -> AppRouter<State> {
         .route(
             "/:userId",
             delete_with(delete, |o| {
-                o.tag(TAG).id("members.delete").summary("Ban Member")
+                o.tag(TAG).id("members.delete").summary("Kick Member")
             }),
         )
         .route(

--- a/apps/superego/src/routes/spaces/mod.rs
+++ b/apps/superego/src/routes/spaces/mod.rs
@@ -28,6 +28,7 @@ use super::{
     ws::{state::State, SocketAction},
 };
 
+pub mod bans;
 pub mod invites;
 pub mod members;
 pub mod roles;

--- a/crates/mikoto-client/src/cache.rs
+++ b/crates/mikoto-client/src/cache.rs
@@ -51,7 +51,11 @@ impl Cache {
         self.roles.get(&id)
     }
 
-    pub fn member(&self, space_id: Uuid, user_id: Uuid) -> Option<Ref<'_, (Uuid, Uuid), MemberExt>> {
+    pub fn member(
+        &self,
+        space_id: Uuid,
+        user_id: Uuid,
+    ) -> Option<Ref<'_, (Uuid, Uuid), MemberExt>> {
         self.members.get(&(space_id, user_id))
     }
 

--- a/crates/mikoto-client/src/generated.rs
+++ b/crates/mikoto-client/src/generated.rs
@@ -13,6 +13,26 @@ use crate::error::ClientError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct BanCreatePayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    pub user_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BanInfo {
+    pub id: Uuid,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    pub space_id: Uuid,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<User>,
+    pub user_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BotCreatedResponse {
     pub id: Uuid,
     pub name: String,
@@ -1094,6 +1114,32 @@ impl<'a> HttpApi<'a> {
         req = req.json(body);
         let resp = req.send().await?.error_for_status()?;
         Ok(resp.json().await?)
+    }
+
+    pub async fn bans_list(&self, space_id: Uuid) -> Result<Vec<BanInfo>, ClientError> {
+        let path = format!("/spaces/{}/bans/", space_id);
+        let mut req = self.client.get(self.url(&path))
+            .bearer_auth(self.token);
+        let resp = req.send().await?.error_for_status()?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn bans_create(&self, space_id: Uuid, body: &BanCreatePayload) -> Result<BanInfo, ClientError> {
+        let path = format!("/spaces/{}/bans/", space_id);
+        let mut req = self.client.post(self.url(&path))
+            .bearer_auth(self.token);
+        req = req.json(body);
+        let resp = req.send().await?.error_for_status()?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn bans_delete(&self, space_id: Uuid, user_id: Uuid) -> Result<(), ClientError> {
+        let path = format!("/spaces/{}/bans/{}", space_id, user_id);
+        let mut req = self.client.delete(self.url(&path))
+            .bearer_auth(self.token);
+        let resp = req.send().await?.error_for_status()?;
+        let _ = resp.text().await?;
+        Ok(())
     }
 
     pub async fn invites_list(&self, space_id: Uuid) -> Result<Vec<Invite>, ClientError> {

--- a/examples/ping-bot/src/main.rs
+++ b/examples/ping-bot/src/main.rs
@@ -42,7 +42,10 @@ impl EventHandler for PingBot {
     }
 
     async fn channel_create(&self, _ctx: Context, channel: Channel) {
-        println!("New channel '{}' in space {}", channel.name, channel.space_id);
+        println!(
+            "New channel '{}' in space {}",
+            channel.name, channel.space_id
+        );
     }
 }
 

--- a/packages/mikoto.js/src/api.gen.ts
+++ b/packages/mikoto.js/src/api.gen.ts
@@ -374,6 +374,21 @@ export const RolePatch = z.object({
 });
 export type RolePatch = z.infer<typeof RolePatch>;
 
+export const BanInfo = z.object({
+  id: z.string().uuid(),
+  reason: z.union([z.string(), z.null()]).optional(),
+  spaceId: z.string().uuid(),
+  user: z.union([User, z.null()]).optional(),
+  userId: z.string().uuid(),
+});
+export type BanInfo = z.infer<typeof BanInfo>;
+
+export const BanCreatePayload = z.object({
+  reason: z.union([z.string(), z.null()]).optional(),
+  userId: z.string().uuid(),
+});
+export type BanCreatePayload = z.infer<typeof BanCreatePayload>;
+
 export const Invite = z.object({
   createdAt: Timestamp.datetime({ offset: true }),
   creatorId: z.string().uuid(),
@@ -469,6 +484,8 @@ export const schemas = {
   MemberUpdatePayload,
   RoleCreatePayload,
   RolePatch,
+  BanInfo,
+  BanCreatePayload,
   Invite,
   InviteCreatePayload,
   ListQuery,
@@ -753,6 +770,34 @@ const endpoints = makeApi([
       },
     ],
     response: SpaceExt,
+  },
+  {
+    method: "get",
+    path: "/spaces/:spaceId/bans/",
+    alias: "bans.list",
+    requestFormat: "json",
+    response: z.array(BanInfo),
+  },
+  {
+    method: "post",
+    path: "/spaces/:spaceId/bans/",
+    alias: "bans.create",
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: BanCreatePayload,
+      },
+    ],
+    response: BanInfo,
+  },
+  {
+    method: "delete",
+    path: "/spaces/:spaceId/bans/:userId",
+    alias: "bans.delete",
+    requestFormat: "json",
+    response: z.null(),
   },
   {
     method: "get",

--- a/packages/mikoto.js/src/managers/space/member.ts
+++ b/packages/mikoto.js/src/managers/space/member.ts
@@ -60,6 +60,13 @@ export class MikotoMember extends ZSchema(MemberExt) {
     });
   }
 
+  async ban(reason?: string) {
+    await this.client.rest['bans.create'](
+      { userId: this.userId, reason: reason ?? null },
+      { params: { spaceId: this.spaceId } },
+    );
+  }
+
   checkPermission(action: string | bigint) {
     if (!this.space) return false;
     if (this.isOwner) return true;


### PR DESCRIPTION
## Summary

Previously, `DELETE /spaces/:spaceId/members/:userId` always created a ban record when removing a member — there was no way to kick without banning. This PR separates them:

- **Kick** (`DELETE /members/:userId`) — removes the member from the space. They can rejoin via invite.
- **Ban** (`POST /bans/`) — creates a ban record and removes the member. They cannot rejoin.
- **Unban** (`DELETE /bans/:userId`) — removes the ban record.
- **List bans** (`GET /bans/`) — returns all bans with user info.

Both kick and ban require the existing `BAN` permission. The UI context menu now shows both "Kick" and "Ban" as separate options.

## Test plan

- [ ] Kick a member and verify they are removed but can rejoin via invite
- [ ] Ban a member and verify they are removed and cannot rejoin
- [ ] Unban a user and verify they can rejoin
- [ ] List bans and verify banned users appear with user info
- [ ] Verify permission checks work for both actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)