### PR TITLE
Fix PWA production build by adding missing workbox-window dependency

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -126,6 +126,7 @@
     "vite": "^5.2.12",
     "vite-plugin-pwa": "^1.2.0",
     "vite-tsconfig-paths": "^4.3.2",
-    "vitest": "^3.1.1"
+    "vitest": "^3.1.1",
+    "workbox-window": "^7.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,9 @@ importers:
       vitest:
         specifier: ^3.1.1
         version: 3.1.1(@types/debug@4.1.12)(@types/node@22.7.2)(terser@5.33.0)
+      workbox-window:
+        specifier: ^7.4.0
+        version: 7.4.0
 
   apps/desktop:
     dependencies:


### PR DESCRIPTION
## Summary

- `vite-plugin-pwa` requires `workbox-window` to resolve `virtual:pwa-register` at build time, but it wasn't listed as a dependency
- This caused Rollup to fail during production builds with an unresolved import error
- Added `workbox-window` as a dev dependency to fix the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)