### PR TITLE
Fix PWA cache failure on large assets

### DIFF
--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -61,6 +61,7 @@ export default ({ mode }: { mode: string }) =>
           ],
         },
         workbox: {
+          maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
           globPatterns: ['**/*.{js,css,html,ico,svg,woff,woff2,ttf}'],
           navigateFallback: 'index.html',
           runtimeCaching: [


### PR DESCRIPTION
## Summary

- Increases the workbox `maximumFileSizeToCacheInBytes` limit to 10 MB to prevent service worker precaching from silently skipping large bundled assets (e.g. JS chunks exceeding the default 2 MB limit), which could cause the PWA to break when offline.

## Test plan

- [ ] Build the client (`moon client:build`) and verify no workbox warnings about skipped files
- [ ] Confirm the service worker precaches all expected assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)