### PR TITLE
Fix duplicate handles by auto-assigning unique defaults

### DIFF
--- a/apps/superego/src/entities/handle.rs
+++ b/apps/superego/src/entities/handle.rs
@@ -316,6 +316,65 @@ impl Handle {
         Ok(result)
     }
 
+    /// Sanitize a display name into a valid username for a default handle.
+    /// Lowercases, replaces invalid chars with hyphens, trims, and falls back to "user".
+    pub fn sanitize_username(name: &str) -> String {
+        let sanitized: String = name
+            .to_lowercase()
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '-'
+                }
+            })
+            .collect();
+        let trimmed = sanitized.trim_matches('-').trim_matches('_');
+        if trimmed.is_empty() || trimmed.len() < 2 {
+            "user".to_string()
+        } else if trimmed.len() > 60 {
+            // Leave room for discriminator suffix
+            trimmed[..60].trim_end_matches('-').trim_end_matches('_').to_string()
+        } else {
+            trimmed.to_string()
+        }
+    }
+
+    /// Auto-generate a unique default handle for a user based on their display name.
+    /// Tries the sanitized name first, then appends short discriminators on conflict.
+    pub async fn auto_assign_for_user(
+        user_id: Uuid,
+        name: &str,
+        db: &sqlx::PgPool,
+    ) -> Result<Self, Error> {
+        let base = Self::sanitize_username(name);
+
+        // Try the base username first
+        let handle = Self::make_default_handle(&base);
+        match Self::claim_for_user(handle, user_id, db).await {
+            Ok(h) => return Ok(h),
+            Err(Error::Miscallaneous { ref code, .. }) if code == "HandleTaken" => {}
+            Err(e) => return Err(e),
+        }
+
+        // Try with short discriminators derived from the user's UUID
+        let id_hex = user_id.as_simple().to_string();
+        for len in [3, 4, 6, 8] {
+            let discriminator = &id_hex[..len];
+            let handle = Self::make_default_handle(&format!("{}-{}", base, discriminator));
+            match Self::claim_for_user(handle, user_id, db).await {
+                Ok(h) => return Ok(h),
+                Err(Error::Miscallaneous { ref code, .. }) if code == "HandleTaken" => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        // Final fallback: full UUID prefix (very unlikely to reach here)
+        let handle = Self::make_default_handle(&format!("{}-{}", base, &id_hex[..12]));
+        Self::claim_for_user(handle, user_id, db).await
+    }
+
     /// Resolve a handle to its owner
     pub async fn resolve<'c, X: sqlx::PgExecutor<'c>>(
         handle: &str,

--- a/apps/superego/src/entities/user.rs
+++ b/apps/superego/src/entities/user.rs
@@ -121,32 +121,10 @@ impl User {
 }
 
 impl UserExt {
-    /// Generate a default handle from a user's display name.
-    /// Lowercases, replaces spaces/invalid chars with hyphens, and appends the handle domain.
-    fn default_handle(name: &str) -> String {
-        let sanitized: String = name
-            .to_lowercase()
-            .chars()
-            .map(|c| {
-                if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                    c
-                } else {
-                    '-'
-                }
-            })
-            .collect();
-        let trimmed = sanitized.trim_matches('-').trim_matches('_');
-        let username = if trimmed.is_empty() { "user" } else { trimmed };
-        Handle::make_default_handle(username)
-    }
-
     pub async fn from_user<'c, X: sqlx::PgExecutor<'c>>(user: User, db: X) -> Result<Self, Error> {
         let handle = Handle::for_user(user.id, db).await?;
-        let handle = handle
-            .map(|h| h.handle)
-            .unwrap_or_else(|| Self::default_handle(&user.name));
         Ok(Self {
-            handle: Some(handle),
+            handle: handle.map(|h| h.handle),
             base: user,
         })
     }
@@ -161,12 +139,9 @@ impl UserExt {
         Ok(users
             .into_iter()
             .map(|user| {
-                let handle = handles
-                    .get(&user.id)
-                    .cloned()
-                    .unwrap_or_else(|| Self::default_handle(&user.name));
+                let handle = handles.get(&user.id).cloned();
                 Self {
-                    handle: Some(handle),
+                    handle,
                     base: user,
                 }
             })

--- a/apps/superego/src/routes/account/register.rs
+++ b/apps/superego/src/routes/account/register.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::{
     db::db,
-    entities::{Account, RefreshToken, TokenPair},
+    entities::{Account, Handle, RefreshToken, TokenPair},
     error::Error,
     functions::{
         captcha::captcha,
@@ -50,6 +50,9 @@ pub async fn route(
     };
 
     account.create_with_user(&body.name, db()).await?;
+
+    // Auto-assign a unique default handle for the new user
+    let _ = Handle::auto_assign_for_user(account.id, &body.name, db()).await;
 
     let (refresh, token) = RefreshToken::new(account.id);
     refresh.create(db()).await?;

--- a/apps/superego/src/routes/users/mod.rs
+++ b/apps/superego/src/routes/users/mod.rs
@@ -23,8 +23,18 @@ pub mod relations;
 
 async fn me(claim: Claims) -> Result<Json<UserExt>, Error> {
     let user = User::find_by_id(claim.sub.parse()?, db()).await?;
-    let user = UserExt::from_user(user, db()).await?;
-    Ok(user.into())
+    let mut user_ext = UserExt::from_user(user, db()).await?;
+
+    // Backfill: auto-assign a handle for users who don't have one yet
+    if user_ext.handle.is_none() {
+        if let Ok(h) =
+            Handle::auto_assign_for_user(user_ext.base.id, &user_ext.base.name, db()).await
+        {
+            user_ext.handle = Some(h.handle);
+        }
+    }
+
+    Ok(user_ext.into())
 }
 
 async fn update(claim: Claims, Json(patch): Json<UserPatch>) -> Result<Json<UserExt>, Error> {


### PR DESCRIPTION
## Summary

- **Fixed**: Users without a claimed handle were given "virtual" handles derived from their display name at query time. Two users with the same name (e.g. "Hayley") would both appear as `hayley.mikoto.io`, even though neither actually owned it in the database.
- **Now**: Handles are auto-assigned as real database entries with uniqueness enforced by the primary key constraint.
  - New users get a handle on registration
  - Existing users without handles get backfilled on their next login (`GET /users/me`)
  - If the base name is taken, discriminators from the user's UUID are appended (e.g. `hayley-a3f.mikoto.io`)

## Test plan

- [ ] Register a new user and verify they receive a handle automatically
- [ ] Register two users with the same display name and verify they get different handles
- [ ] Log in as an existing user without a handle and verify one is assigned on the `/users/me` response
- [ ] Verify manually-set handles are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)