### PR TITLE
Add code block shortcut and floating formatting toolbar to documents

### DIFF
--- a/apps/client/src/components/surfaces/Documents/index.tsx
+++ b/apps/client/src/components/surfaces/Documents/index.tsx
@@ -39,7 +39,9 @@ import { useMikoto } from '@/hooks';
 import { createTooltip } from '@/ui';
 
 import { EDITOR_NODES } from './editorNodes';
+import { CodeBlockPlugin } from './plugins/CodeBlockPlugin';
 import { EmptyParagraphPlugin } from './plugins/EmptyParagraphPlugin';
+import { FloatingToolbarPlugin } from './plugins/FloatingToolbarPlugin';
 import { HotkeyPlugin } from './plugins/HotkeyPlugin';
 import { ListBehaviorPlugin } from './plugins/ListBehaviorPlugin';
 import { MarkdownPastePlugin } from './plugins/MarkdownPastePlugin';
@@ -102,6 +104,26 @@ const EditorWrapper = styled.div`
 
   a {
     color: #00aff4;
+  }
+
+  .editor-code {
+    display: block;
+    background-color: var(--chakra-colors-gray-800);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.9em;
+    line-height: 1.5;
+    padding: 12px 16px;
+    margin: 8px 0;
+    overflow-x: auto;
+    tab-size: 2;
+    white-space: pre;
+  }
+
+  .editor-text-code {
+    background-color: var(--chakra-colors-gray-800);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.9em;
+    padding: 1px 4px;
   }
 `;
 
@@ -260,7 +282,9 @@ function DocumentEditor({
       <AutoLinkPlugin matchers={LINK_MATCHERS} />
       <HotkeyPlugin channel={channel} />
       <ListBehaviorPlugin />
+      <CodeBlockPlugin />
       <EmptyParagraphPlugin />
+      <FloatingToolbarPlugin />
       <OnChangePlugin ignoreSelectionChange onChange={onChange} />
       <HistoryPlugin />
     </LexicalComposer>

--- a/apps/client/src/components/surfaces/Documents/plugins/CodeBlockPlugin.tsx
+++ b/apps/client/src/components/surfaces/Documents/plugins/CodeBlockPlugin.tsx
@@ -1,0 +1,60 @@
+import { $createCodeNode } from '@lexical/code';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import {
+  $getSelection,
+  $isParagraphNode,
+  $isRangeSelection,
+  $isTextNode,
+  COMMAND_PRIORITY_HIGH,
+  KEY_ENTER_COMMAND,
+} from 'lexical';
+import { useEffect } from 'react';
+
+/**
+ * Plugin that converts triple backticks (```) into a code block on Enter.
+ * The built-in markdown shortcut requires a space after ```, which conflicts
+ * with the inline code formatter consuming backticks. This plugin intercepts
+ * Enter instead, creating a code block when the line is just ```.
+ */
+export function CodeBlockPlugin() {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_ENTER_COMMAND,
+      (event) => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+          return false;
+        }
+
+        const anchorNode = selection.anchor.getNode();
+        if (!$isTextNode(anchorNode)) {
+          return false;
+        }
+
+        const parentNode = anchorNode.getParent();
+        if (!$isParagraphNode(parentNode)) {
+          return false;
+        }
+
+        const text = anchorNode.getTextContent();
+        const match = text.match(/^```(\w{1,10})?$/);
+        if (!match) {
+          return false;
+        }
+
+        event?.preventDefault();
+
+        const codeNode = $createCodeNode(match[1] || undefined);
+        parentNode.replace(codeNode);
+        codeNode.selectStart();
+
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+  }, [editor]);
+
+  return null;
+}

--- a/apps/client/src/components/surfaces/Documents/plugins/FloatingToolbarPlugin.tsx
+++ b/apps/client/src/components/surfaces/Documents/plugins/FloatingToolbarPlugin.tsx
@@ -1,0 +1,262 @@
+import { $isLinkNode, TOGGLE_LINK_COMMAND } from '@lexical/link';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import {
+  faBold,
+  faCode,
+  faItalic,
+  faLink,
+  faStrikethrough,
+  faUnderline,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import styled from '@emotion/styled';
+import {
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_LOW,
+  FORMAT_TEXT_COMMAND,
+  SELECTION_CHANGE_COMMAND,
+} from 'lexical';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { $isAtNodeEnd } from '@lexical/selection';
+import { mergeRegister } from '@lexical/utils';
+
+function getSelectedNode(selection: ReturnType<typeof $getSelection>) {
+  if (!$isRangeSelection(selection)) return null;
+  const anchor = selection.anchor;
+  const focus = selection.focus;
+  const anchorNode = anchor.getNode();
+  const focusNode = focus.getNode();
+  if (anchorNode === focusNode) return anchorNode;
+  const isBackward = selection.isBackward();
+  if (isBackward) {
+    return $isAtNodeEnd(focus) ? anchorNode : focusNode;
+  }
+  return $isAtNodeEnd(anchor) ? focusNode : anchorNode;
+}
+
+const ToolbarContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  background: var(--chakra-colors-gray-800);
+  border: 1px solid var(--chakra-colors-gray-600);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  position: absolute;
+  z-index: 100;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+
+  &.visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+`;
+
+const ToolbarButton = styled.button<{ active?: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: ${(p) =>
+    p.active ? 'var(--chakra-colors-gray-600)' : 'transparent'};
+  color: ${(p) =>
+    p.active ? 'var(--chakra-colors-gray-50)' : 'var(--chakra-colors-gray-300)'};
+  cursor: pointer;
+  font-size: 13px;
+
+  &:hover {
+    background: var(--chakra-colors-gray-700);
+    color: var(--chakra-colors-gray-50);
+  }
+`;
+
+const Divider = styled.div`
+  width: 1px;
+  height: 20px;
+  background: var(--chakra-colors-gray-600);
+  margin: 0 2px;
+`;
+
+function FloatingToolbar({
+  editor,
+  anchorElem,
+}: {
+  editor: ReturnType<typeof useLexicalComposerContext>[0];
+  anchorElem: HTMLElement;
+}) {
+  const toolbarRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const [isBold, setIsBold] = useState(false);
+  const [isItalic, setIsItalic] = useState(false);
+  const [isUnderline, setIsUnderline] = useState(false);
+  const [isStrikethrough, setIsStrikethrough] = useState(false);
+  const [isCode, setIsCode] = useState(false);
+  const [isLink, setIsLink] = useState(false);
+
+  const updateToolbar = useCallback(() => {
+    editor.getEditorState().read(() => {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection) || selection.isCollapsed()) {
+        setIsVisible(false);
+        return;
+      }
+
+      setIsBold(selection.hasFormat('bold'));
+      setIsItalic(selection.hasFormat('italic'));
+      setIsUnderline(selection.hasFormat('underline'));
+      setIsStrikethrough(selection.hasFormat('strikethrough'));
+      setIsCode(selection.hasFormat('code'));
+
+      const node = getSelectedNode(selection);
+      const parent = node?.getParent();
+      setIsLink($isLinkNode(parent) || $isLinkNode(node));
+
+      // Position the toolbar
+      const nativeSelection = window.getSelection();
+      if (!nativeSelection || nativeSelection.rangeCount === 0) {
+        setIsVisible(false);
+        return;
+      }
+
+      const range = nativeSelection.getRangeAt(0);
+      const rect = range.getBoundingClientRect();
+
+      if (rect.width === 0 && rect.height === 0) {
+        setIsVisible(false);
+        return;
+      }
+
+      const toolbar = toolbarRef.current;
+      if (!toolbar) return;
+
+      const toolbarWidth = toolbar.offsetWidth;
+      const toolbarHeight = toolbar.offsetHeight;
+
+      const top = rect.top - toolbarHeight - 8 + window.scrollY;
+      const left =
+        rect.left + rect.width / 2 - toolbarWidth / 2 + window.scrollX;
+
+      toolbar.style.top = `${Math.max(0, top)}px`;
+      toolbar.style.left = `${Math.max(0, left)}px`;
+
+      setIsVisible(true);
+    });
+  }, [editor]);
+
+  useEffect(() => {
+    return mergeRegister(
+      editor.registerUpdateListener(({ editorState }) => {
+        editorState.read(() => {
+          updateToolbar();
+        });
+      }),
+      editor.registerCommand(
+        SELECTION_CHANGE_COMMAND,
+        () => {
+          updateToolbar();
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+    );
+  }, [editor, updateToolbar]);
+
+  // Also update on mouse up to catch drag selections
+  useEffect(() => {
+    const onMouseUp = () => {
+      setTimeout(updateToolbar, 0);
+    };
+    document.addEventListener('mouseup', onMouseUp);
+    return () => document.removeEventListener('mouseup', onMouseUp);
+  }, [updateToolbar]);
+
+  const toggleLink = useCallback(() => {
+    if (isLink) {
+      editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
+    } else {
+      editor.dispatchCommand(TOGGLE_LINK_COMMAND, 'https://');
+    }
+  }, [editor, isLink]);
+
+  return createPortal(
+    <ToolbarContainer
+      ref={toolbarRef}
+      className={isVisible ? 'visible' : ''}
+    >
+      <ToolbarButton
+        active={isBold}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
+        }}
+        title="Bold (Ctrl+B)"
+      >
+        <FontAwesomeIcon icon={faBold} />
+      </ToolbarButton>
+      <ToolbarButton
+        active={isItalic}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
+        }}
+        title="Italic (Ctrl+I)"
+      >
+        <FontAwesomeIcon icon={faItalic} />
+      </ToolbarButton>
+      <ToolbarButton
+        active={isUnderline}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'underline');
+        }}
+        title="Underline (Ctrl+U)"
+      >
+        <FontAwesomeIcon icon={faUnderline} />
+      </ToolbarButton>
+      <ToolbarButton
+        active={isStrikethrough}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'strikethrough');
+        }}
+        title="Strikethrough"
+      >
+        <FontAwesomeIcon icon={faStrikethrough} />
+      </ToolbarButton>
+      <Divider />
+      <ToolbarButton
+        active={isCode}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
+        }}
+        title="Inline Code"
+      >
+        <FontAwesomeIcon icon={faCode} />
+      </ToolbarButton>
+      <ToolbarButton
+        active={isLink}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          toggleLink();
+        }}
+        title="Link"
+      >
+        <FontAwesomeIcon icon={faLink} />
+      </ToolbarButton>
+    </ToolbarContainer>,
+    document.body,
+  );
+}
+
+export function FloatingToolbarPlugin() {
+  const [editor] = useLexicalComposerContext();
+
+  return <FloatingToolbar editor={editor} anchorElem={document.body} />;
+}


### PR DESCRIPTION
## Summary

- **Code block shortcut**: Typing ``` and pressing Enter now creates a code block, with optional language tag support (e.g. ```js). This works around the built-in markdown shortcut conflicting with the inline code backtick formatter.
- **Floating toolbar**: Selecting text in the document editor now shows a floating toolbar with formatting options (bold, italic, underline, strikethrough, inline code, link). Makes rich text formatting discoverable without keyboard shortcuts.
- **Code styling**: Added styles for both code blocks and inline code using JetBrains Mono.

🤖 Generated with [Claude Code](https://claude.com/claude-code)