### PR TITLE
Rename default branch from dev to main

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -6,7 +6,7 @@ description: Creates a pull request using the GitHub CLI.
 Steps:
 
 1. Push the current branch to origin if not already pushed. If there are uncommitted changes, use /commit first.
-2. Use `gh pr create` to create the pull request. Keep in mind that the base branch is named `dev`, not `main`.
+2. Use `gh pr create` to create the pull request.
 3. Return the PR URL.
 
 Write a concise PR title and description summarizing the changes. The description should include a comprehensive, yet concise description of everything that changed in the PR.

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -24,5 +24,3 @@ Steps:
    - **Abort rebase** — run `git rebase --abort` and stop
 5. After resolving all files in the current step: `git add <files>` and `git rebase --continue`.
 6. Repeat until the rebase completes or the user aborts.
-
-Always use `dev` as the base branch, not `main` or `master`.

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: rebase
-description: Rebases the current branch onto the latest dev branch.
+description: Rebases the current branch onto the latest main branch.
 ---
 
 Steps:
 
 1. Fetch the latest changes from origin.
-2. Rebase the current branch onto `origin/dev`.
+2. Rebase the current branch onto `origin/main`.
 3. If there are conflicts, resolve conflicts automatically, trying to preserve features from both branches.
 
 ## Conflict resolution

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -10,4 +10,4 @@ projects:
   - 'packages/*'
 vcs:
   manager: 'git'
-  defaultBranch: 'dev'
+  defaultBranch: 'main'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,4 +89,3 @@ All Mikoto services use ports in the `351X` or `351XX` range to avoid conflicts 
 - Before adding any new package, use the rustdoc crate search to check for the version.
 - Instead of reading the migrations, you can read schema.sql for the up-to-date dump of the database schema.
 - at the end of your task, run moon :typecheck to check both Rust and TypeScript parts of the codebase.
-- the main branch is named `dev`, not `main` - the branch `main` or `master` doesn't exist in this project, and all git operations should assume `dev` to be the trunk.


### PR DESCRIPTION
## Summary

The repository's default branch has been renamed from `dev` to `main`. This PR updates all internal references to reflect that change:

- Moon workspace config (`defaultBranch`)
- Claude Code skill definitions (rebase and create-pr skills)
- CLAUDE.md project instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)