### PR TITLE
Add dev container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+{
+  "name": "Mikoto",
+  "dockerComposeFile": ["../docker-compose.yml", "docker-compose.yml"],
+  "service": "devcontainer",
+  "workspaceFolder": "/workspaces/mikoto",
+
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "1.89",
+      "profile": "default"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22",
+      "installYarnUsingApt": false
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        "ms-azuretools.vscode-docker"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "rust-analyzer.check.command": "clippy"
+      }
+    }
+  },
+
+  "forwardPorts": [3510, 3511, 3512, 3513, 35101, 35102, 35103, 35104],
+
+  "postCreateCommand": ".devcontainer/post-create.sh",
+
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  devcontainer:
+    image: mcr.microsoft.com/devcontainers/base:ubuntu
+    volumes:
+      - ..:/workspaces/mikoto:cached
+    command: sleep infinity
+    depends_on:
+      - postgres
+      - redis
+      - minio

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+echo "Installing pnpm..."
+corepack enable
+corepack prepare pnpm@latest --activate
+
+echo "Installing Moon..."
+curl -fsSL https://moonrepo.dev/install/moon.sh | bash
+echo 'export PATH="$HOME/.moon/bin:$PATH"' >> ~/.bashrc
+
+echo "Installing just..."
+curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/.local/bin
+
+echo "Installing Node dependencies..."
+pnpm install
+
+echo "Installing sqlx-cli..."
+cargo install sqlx-cli --no-default-features --features postgres
+
+echo "Dev environment ready!"


### PR DESCRIPTION
## Summary

- Adds a `.devcontainer/` setup so contributors can spin up a fully configured development environment in VS Code or GitHub Codespaces with one click
- Includes Rust, Node.js, pnpm, Moon, just, and sqlx-cli tooling, plus VS Code extensions for rust-analyzer, ESLint, Prettier, and Tailwind
- Composes with the existing `docker-compose.yml` to provide Postgres, Redis, and MinIO alongside the dev container

## Test plan

- [ ] Open repo in VS Code with Dev Containers extension and verify container builds successfully
- [ ] Verify `post-create.sh` installs all tools (pnpm, moon, just, sqlx-cli)
- [ ] Verify forwarded ports match the project's port configuration
- [ ] Test in GitHub Codespaces if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)