### PR TITLE
Add typing & status indicators with bot differentiation

### DIFF
--- a/apps/client/src/components/sidebars/MemberListSidebar.tsx
+++ b/apps/client/src/components/sidebars/MemberListSidebar.tsx
@@ -4,7 +4,7 @@ import { faCrown, faGlasses } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { MikotoMember, MikotoSpace } from '@mikoto-io/mikoto.js';
 import { useSetAtom } from 'jotai';
-import { useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 import { useSnapshot } from 'valtio';
 
@@ -14,7 +14,47 @@ import { MemberContextMenu } from '@/components/atoms/MessageAvatar';
 import { hoverableButtonLike } from '@/components/design';
 import { UserContextMenu } from '@/components/modals/ContextMenus';
 import { Tag } from '@/components/ui';
-import { useFetchMember } from '@/hooks';
+import { useFetchMember, useInterval, useMikoto } from '@/hooks';
+
+interface ActiveTyper {
+  userId: string;
+  timestamp: number;
+}
+
+function useActiveTypers(spaceId: string): Set<string> {
+  const mikoto = useMikoto();
+  const [typers, setTypers] = useState<ActiveTyper[]>([]);
+
+  useEffect(() => {
+    const handler = (ev: { channelId: string; userId: string }) => {
+      // Only track typing for channels in this space
+      const channel = mikoto.channels._get(ev.channelId);
+      if (!channel || channel.spaceId !== spaceId) return;
+
+      setTypers((prev) => {
+        const next = [...prev];
+        const existing = next.find((t) => t.userId === ev.userId);
+        if (existing) {
+          existing.timestamp = Date.now() + 5000;
+        } else {
+          next.push({ userId: ev.userId, timestamp: Date.now() + 5000 });
+        }
+        return next;
+      });
+    };
+    mikoto.ws.on('typing.onUpdate', handler);
+    return () => {
+      mikoto.ws.off('typing.onUpdate', handler);
+    };
+  }, [spaceId]);
+
+  useInterval(() => {
+    if (typers.length === 0) return;
+    setTypers((prev) => prev.filter((t) => t.timestamp > Date.now()));
+  }, 500);
+
+  return new Set(typers.map((t) => t.userId));
+}
 
 const StyledMember = styled.div`
   display: flex;
@@ -25,7 +65,32 @@ const StyledMember = styled.div`
   ${hoverableButtonLike}
 `;
 
-function MemberElement({ member }: { member: MikotoMember }) {
+const PulsingDot = styled.span`
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--chakra-colors-green-400);
+  margin-left: 4px;
+  animation: pulse 1.2s ease-in-out infinite;
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.3;
+    }
+  }
+`;
+
+function MemberElement({
+  member,
+  isTyping,
+}: {
+  member: MikotoMember;
+  isTyping?: boolean;
+}) {
   const setContextMenu = useSetAtom(contextMenuState);
   const elemRef = useRef<HTMLDivElement>(null);
 
@@ -77,6 +142,7 @@ function MemberElement({ member }: { member: MikotoMember }) {
           <FontAwesomeIcon icon={faGlasses} />
         </Tag>
       )}
+      {isTyping && member.user.category === 'BOT' && <PulsingDot />}
     </StyledMember>
   );
 }
@@ -89,6 +155,7 @@ const StyledMemberListSidebar = styled.div`
 
 export function MemberListSidebar({ space }: { space: MikotoSpace }) {
   useFetchMember(space);
+  const activeTypers = useActiveTypers(space.id);
 
   // Use a snapshot of the members cache to ensure reactivity
   const members = useSnapshot(space.members.cache);
@@ -101,7 +168,12 @@ export function MemberListSidebar({ space }: { space: MikotoSpace }) {
       <Virtuoso
         style={{ height: '100%', overflowX: 'hidden' }}
         data={spaceMembers}
-        itemContent={(_idx, member) => <MemberElement member={member} />}
+        itemContent={(_idx, member) => (
+          <MemberElement
+            member={member}
+            isTyping={activeTypers.has(member.user.id)}
+          />
+        )}
       />
     </StyledMemberListSidebar>
   );

--- a/apps/client/src/components/surfaces/Messages/TypingIndicator.tsx
+++ b/apps/client/src/components/surfaces/Messages/TypingIndicator.tsx
@@ -25,24 +25,45 @@ export interface TypingIndicatorProps {
   channel: MikotoChannel;
 }
 
+function formatTyperGroup(names: string[], verb: string) {
+  if (names.length === 0) return null;
+  const joined = names.join(', ');
+  const plural = names.length > 1 ? `are ${verb}` : `is ${verb}`;
+  return (
+    <>
+      <strong>{joined}</strong> {plural}
+    </>
+  );
+}
+
 export function TypingIndicator({ typers, channel }: TypingIndicatorProps) {
   const mikoto = useMikoto();
+
+  const space = mikoto.spaces._get(channel.spaceId);
+  const humanNames: string[] = [];
+  const botNames: string[] = [];
+
+  for (const t of typers) {
+    const member = space?.members?._get(t.userId);
+    const name = member?.user.name ?? 'Unknown';
+    if (member?.user.category === 'BOT') {
+      botNames.push(name);
+    } else {
+      humanNames.push(name);
+    }
+  }
+
+  const humanPart = formatTyperGroup(humanNames, 'typing...');
+  const botPart = formatTyperGroup(botNames, 'thinking...');
 
   return (
     <Box px={4} fontSize="12px">
       {typers.length > 0 && (
         <div>
           <TypingDots />
-          <strong>
-            {typers
-              .map(
-                (x) =>
-                  mikoto.spaces._get(channel.spaceId)?.members?._get(x.userId)
-                    ?.user.name ?? 'Unknown',
-              )
-              .join(', ')}
-          </strong>{' '}
-          is typing...
+          {humanPart}
+          {humanPart && botPart && ' '}
+          {botPart}
         </div>
       )}
     </Box>

--- a/apps/client/src/components/surfaces/Messages/index.tsx
+++ b/apps/client/src/components/surfaces/Messages/index.tsx
@@ -84,45 +84,40 @@ function RealMessageView({ channel }: { channel: MikotoChannel }) {
   const currentEditState = useAtomValue(messageEditState);
   const setEditState = useSetAtom(messageEditState);
 
-  // TODO: When I wrote this code, only God and I understood what I was doing
-  // At this point, I don't think God understands it either
-  // useEffect(
-  //   () =>
-  //     mikoto.client.messages.onTypingStart((ev) => {
-  //       if (ev.channelId !== channel.id) return;
-  //       if (ev.userId === mikoto.me.id) return;
+  useEffect(() => {
+    const handler = (ev: { channelId: string; userId: string }) => {
+      if (ev.channelId !== channel.id) return;
+      if (ev.userId === mikoto.user.me?.id) return;
 
-  //       setCurrentTypers((cts) => {
-  //         const ct = [...cts];
-  //         let exists = false;
-  //         ct.forEach((x) => {
-  //           if (x.userId === ev.userId) {
-  //             exists = true;
-  //             x.timestamp = Date.now() + 5000;
-  //           }
-  //         });
-  //         if (!exists) {
-  //           ct.push({
-  //             timestamp: Date.now() + 5000,
-  //             userId: ev.userId,
-  //           });
-  //         }
-  //         return ct;
-  //       });
-  //     }),
-  //   [channel.id],
-  // );
+      setCurrentTypers((cts) => {
+        const ct = [...cts];
+        let exists = false;
+        ct.forEach((x) => {
+          if (x.userId === ev.userId) {
+            exists = true;
+            x.timestamp = Date.now() + 5000;
+          }
+        });
+        if (!exists) {
+          ct.push({
+            timestamp: Date.now() + 5000,
+            userId: ev.userId,
+          });
+        }
+        return ct;
+      });
+    };
+    mikoto.ws.on('typing.onUpdate', handler);
+    return () => {
+      mikoto.ws.off('typing.onUpdate', handler);
+    };
+  }, [channel.id]);
 
   const typing = useCallback(
     throttle(() => {
-      // TODO: reimplement typing
-      // mikoto.client.messages
-      //   .startTyping({
-      //     channelId: channel.id,
-      //   })
-      //   .then();
+      mikoto.ws.send('typing.start', { channelId: channel.id });
     }, 3000),
-    [],
+    [channel.id],
   );
 
   const [msgs, setMsgs] = useState<MikotoMessage[] | null>(null);

--- a/apps/client/src/components/surfaces/Messages/index.tsx
+++ b/apps/client/src/components/surfaces/Messages/index.tsx
@@ -262,6 +262,7 @@ function RealMessageView({ channel }: { channel: MikotoChannel }) {
               }
             }}
             onSubmit={async (msg, files) => {
+              typing.cancel();
               if (currentEditState) {
                 const m = currentEditState;
                 setEditState(null);

--- a/apps/superego/api.json
+++ b/apps/superego/api.json
@@ -2912,6 +2912,32 @@
           }
         }
       },
+      "TypingStart": {
+        "type": "object",
+        "required": [
+          "channelId"
+        ],
+        "properties": {
+          "channelId": {
+            "type": "string"
+          }
+        }
+      },
+      "TypingUpdate": {
+        "type": "object",
+        "required": [
+          "channelId",
+          "userId"
+        ],
+        "properties": {
+          "channelId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          }
+        }
+      },
       "UpdateBotPayload": {
         "type": "object",
         "properties": {
@@ -3186,6 +3212,9 @@
     "commands": {
       "ping": {
         "$ref": "#/components/schemas/Ping"
+      },
+      "typing.start": {
+        "$ref": "#/components/schemas/TypingStart"
       }
     },
     "events": {
@@ -3236,6 +3265,9 @@
       },
       "spaces.onUpdate": {
         "$ref": "#/components/schemas/SpaceExt"
+      },
+      "typing.onUpdate": {
+        "$ref": "#/components/schemas/TypingUpdate"
       },
       "users.onCreate": {
         "$ref": "#/components/schemas/UserExt"

--- a/apps/superego/src/routes/mod.rs
+++ b/apps/superego/src/routes/mod.rs
@@ -15,6 +15,8 @@ use tower_http::cors::CorsLayer;
 use ws::state::State;
 
 use crate::{
+    db::db,
+    entities::Channel,
     env::{env, MikotoMode},
     functions::pubsub::emit_event,
 };
@@ -52,6 +54,19 @@ pub async fn index() -> Json<&'static IndexResponse> {
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct Ping {
     pub message: String,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TypingStart {
+    pub channel_id: String,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TypingUpdate {
+    pub channel_id: String,
+    pub user_id: String,
 }
 
 fn build_app_router() -> AppRouter<State> {
@@ -102,6 +117,27 @@ fn build_app_router() -> AppRouter<State> {
             Ok(())
         })
         .ws_event("pong", |ping: Ping, _| async move { Some(ping) })
+        .ws_command(
+            "typing.start",
+            |payload: TypingStart, state: Arc<RwLock<State>>| async move {
+                let channel_id: uuid::Uuid = payload.channel_id.parse()?;
+                let channel = Channel::find_by_id(channel_id, db()).await?;
+                let user_id = state.read().await.user.id;
+                emit_event(
+                    "typing.onUpdate",
+                    TypingUpdate {
+                        channel_id: payload.channel_id,
+                        user_id: user_id.to_string(),
+                    },
+                    &format!("space:{}", channel.space_id),
+                )
+                .await?;
+                Ok(())
+            },
+        )
+        .ws_event("typing.onUpdate", |update: TypingUpdate, _| async move {
+            Some(update)
+        })
 }
 
 async fn security_headers(request: Request, next: middleware::Next) -> axum::response::Response {

--- a/crates/mikoto-client/src/bot.rs
+++ b/crates/mikoto-client/src/bot.rs
@@ -2,11 +2,13 @@ use std::sync::Arc;
 
 use uuid::Uuid;
 
+use tokio::sync::mpsc;
+
 use crate::cache::Cache;
 use crate::client::MikotoClient;
 use crate::context::Context;
 use crate::error::ClientError;
-use crate::generated::{BotLoginPayload, WsEvent};
+use crate::generated::{BotLoginPayload, WsCommand, WsEvent};
 use crate::handler::EventHandler;
 
 /// High-level bot client with automatic caching and event dispatch.
@@ -116,52 +118,55 @@ impl BotClient {
         }
     }
 
-    /// Get a [`Context`] handle (useful outside of event handlers).
-    pub fn context(&self) -> Context {
-        Context::new(Arc::clone(&self.http), Arc::clone(&self.cache))
-    }
-
     /// Connect to the WebSocket and run the event loop until disconnected.
     ///
     /// This method blocks until the WebSocket connection is closed.
     pub async fn start(&self) -> Result<(), ClientError> {
         let mut ws = self.http.connect_ws().await?;
+        let (ws_tx, mut ws_rx) = mpsc::unbounded_channel::<WsCommand>();
 
-        let ctx = self.context();
+        let ctx = Context::new(
+            Arc::clone(&self.http),
+            Arc::clone(&self.cache),
+            ws_tx,
+        );
         self.handler.ready(ctx.clone()).await;
 
         tracing::info!("connected to websocket, dispatching events");
 
         loop {
-            let text = match ws.recv_text().await? {
-                Some(t) => t,
-                None => {
-                    tracing::info!("websocket closed");
-                    break;
+            tokio::select! {
+                text = ws.recv_text() => {
+                    let text = match text? {
+                        Some(t) => t,
+                        None => {
+                            tracing::info!("websocket closed");
+                            break;
+                        }
+                    };
+
+                    let event: WsEvent = match serde_json::from_str(&text) {
+                        Ok(ev) => ev,
+                        Err(e) => {
+                            tracing::trace!(error = %e, "skipping unknown ws event");
+                            continue;
+                        }
+                    };
+
+                    // Update cache before dispatching to handler
+                    self.cache.update(&event);
+
+                    let ctx = ctx.clone();
+                    let handler = Arc::clone(&self.handler);
+
+                    tokio::spawn(async move {
+                        dispatch_event(handler.as_ref(), ctx, event).await;
+                    });
                 }
-            };
-
-            let event: WsEvent = match serde_json::from_str(&text) {
-                Ok(ev) => ev,
-                Err(e) => {
-                    // Unknown event ops (e.g. "ready") cause deserialization
-                    // errors — silently skip them.
-                    tracing::trace!(error = %e, "skipping unknown ws event");
-                    continue;
+                Some(cmd) = ws_rx.recv() => {
+                    ws.send(&cmd).await?;
                 }
-            };
-
-            // Update cache before dispatching to handler
-            self.cache.update(&event);
-
-            let ctx = ctx.clone();
-            let handler = Arc::clone(&self.handler);
-
-            // Dispatch to handler in a spawned task so one slow handler
-            // doesn't block the event loop.
-            tokio::spawn(async move {
-                dispatch_event(handler.as_ref(), ctx, event).await;
-            });
+            }
         }
 
         Ok(())
@@ -193,6 +198,8 @@ async fn dispatch_event(handler: &dyn EventHandler, ctx: Context, event: WsEvent
         WsEvent::UsersOnCreate(u) => handler.user_create(ctx, u).await,
         WsEvent::UsersOnUpdate(u) => handler.user_update(ctx, u).await,
         WsEvent::UsersOnDelete(obj) => handler.user_delete(ctx, obj.id).await,
+
+        WsEvent::TypingOnUpdate(u) => handler.typing_update(ctx, u).await,
 
         WsEvent::Pong(_) => {}
     }

--- a/crates/mikoto-client/src/bot.rs
+++ b/crates/mikoto-client/src/bot.rs
@@ -125,11 +125,7 @@ impl BotClient {
         let mut ws = self.http.connect_ws().await?;
         let (ws_tx, mut ws_rx) = mpsc::unbounded_channel::<WsCommand>();
 
-        let ctx = Context::new(
-            Arc::clone(&self.http),
-            Arc::clone(&self.cache),
-            ws_tx,
-        );
+        let ctx = Context::new(Arc::clone(&self.http), Arc::clone(&self.cache), ws_tx);
         self.handler.ready(ctx.clone()).await;
 
         tracing::info!("connected to websocket, dispatching events");

--- a/crates/mikoto-client/src/cache.rs
+++ b/crates/mikoto-client/src/cache.rs
@@ -197,10 +197,11 @@ impl Cache {
                 self.users.remove(&obj.id);
             }
 
-            // Messages and pong don't affect the cache
+            // Messages, typing, and pong don't affect the cache
             WsEvent::MessagesOnCreate(_)
             | WsEvent::MessagesOnDelete(_)
             | WsEvent::MessagesOnUpdate(_)
+            | WsEvent::TypingOnUpdate(_)
             | WsEvent::Pong(_) => {}
         }
     }

--- a/crates/mikoto-client/src/context.rs
+++ b/crates/mikoto-client/src/context.rs
@@ -2,10 +2,12 @@ use std::sync::Arc;
 
 use uuid::Uuid;
 
+use tokio::sync::mpsc;
+
 use crate::cache::Cache;
 use crate::client::MikotoClient;
 use crate::error::ClientError;
-use crate::generated::{HttpApi, MessageExt, MessageSendPayload};
+use crate::generated::{HttpApi, MessageExt, MessageSendPayload, TypingStart, WsCommand};
 
 /// A cheaply cloneable handle that provides access to the HTTP API and cache.
 ///
@@ -15,11 +17,16 @@ use crate::generated::{HttpApi, MessageExt, MessageSendPayload};
 pub struct Context {
     pub(crate) http: Arc<MikotoClient>,
     pub(crate) cache: Arc<Cache>,
+    pub(crate) ws_tx: mpsc::UnboundedSender<WsCommand>,
 }
 
 impl Context {
-    pub(crate) fn new(http: Arc<MikotoClient>, cache: Arc<Cache>) -> Self {
-        Self { http, cache }
+    pub(crate) fn new(
+        http: Arc<MikotoClient>,
+        cache: Arc<Cache>,
+        ws_tx: mpsc::UnboundedSender<WsCommand>,
+    ) -> Self {
+        Self { http, cache, ws_tx }
     }
 
     /// Access the full HTTP API (same as [`MikotoClient::api`]).
@@ -30,6 +37,15 @@ impl Context {
     /// Access the cache.
     pub fn cache(&self) -> &Cache {
         &self.cache
+    }
+
+    /// Send a `typing.start` command over the WebSocket.
+    ///
+    /// In the UI this shows "BotName is thinking..." for bot users.
+    pub fn set_typing(&self, channel_id: Uuid) {
+        let _ = self.ws_tx.send(WsCommand::TypingStart(TypingStart {
+            channel_id: channel_id.to_string(),
+        }));
     }
 
     /// Convenience: send a text message to a channel.

--- a/crates/mikoto-client/src/generated.rs
+++ b/crates/mikoto-client/src/generated.rs
@@ -457,6 +457,19 @@ pub type Timestamp = DateTime<Utc>;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct TypingStart {
+    pub channel_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TypingUpdate {
+    pub channel_id: String,
+    pub user_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TokenPair {
     pub access_token: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1177,6 +1190,8 @@ impl<'a> HttpApi<'a> {
 pub enum WsCommand {
     #[serde(rename = "ping")]
     Ping(Ping),
+    #[serde(rename = "typing.start")]
+    TypingStart(TypingStart),
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1214,6 +1229,8 @@ pub enum WsEvent {
     SpacesOnDelete(SpaceExt),
     #[serde(rename = "spaces.onUpdate")]
     SpacesOnUpdate(SpaceExt),
+    #[serde(rename = "typing.onUpdate")]
+    TypingOnUpdate(TypingUpdate),
     #[serde(rename = "users.onCreate")]
     UsersOnCreate(UserExt),
     #[serde(rename = "users.onDelete")]

--- a/crates/mikoto-client/src/handler.rs
+++ b/crates/mikoto-client/src/handler.rs
@@ -51,6 +51,8 @@ pub trait EventHandler: Send + Sync {
     async fn space_update(&self, _ctx: Context, _space: SpaceExt) {}
     async fn space_delete(&self, _ctx: Context, _space: SpaceExt) {}
 
+    async fn typing_update(&self, _ctx: Context, _update: TypingUpdate) {}
+
     async fn user_create(&self, _ctx: Context, _user: UserExt) {}
     async fn user_update(&self, _ctx: Context, _user: UserExt) {}
     async fn user_delete(&self, _ctx: Context, _id: Uuid) {}

--- a/packages/mikoto.js/src/WebsocketApi.ts
+++ b/packages/mikoto.js/src/WebsocketApi.ts
@@ -39,7 +39,10 @@ export class WebsocketApi extends (EventEmitter as new () => WebsocketEventEmitt
     };
   }
 
-  send<K extends keyof WebsocketCommands>(op: K, data: z.infer<WebsocketCommands[K]>) {
+  send<K extends keyof WebsocketCommands>(
+    op: K,
+    data: z.infer<WebsocketCommands[K]>,
+  ) {
     this.ws.send(
       JSON.stringify({
         op,

--- a/packages/mikoto.js/src/WebsocketApi.ts
+++ b/packages/mikoto.js/src/WebsocketApi.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
 import WebSocket from 'isomorphic-ws';
+import type { z } from 'zod';
 
 import type { WebsocketEventEmitter, websocketCommands } from './api.gen';
 
@@ -38,7 +39,7 @@ export class WebsocketApi extends (EventEmitter as new () => WebsocketEventEmitt
     };
   }
 
-  send<K extends keyof WebsocketCommands>(op: K, data: WebsocketCommands[K]) {
+  send<K extends keyof WebsocketCommands>(op: K, data: z.infer<WebsocketCommands[K]>) {
     this.ws.send(
       JSON.stringify({
         op,

--- a/packages/mikoto.js/src/api.gen.ts
+++ b/packages/mikoto.js/src/api.gen.ts
@@ -420,6 +420,15 @@ export type ObjectWithId = z.infer<typeof ObjectWithId>;
 export const Ping = z.object({ message: z.string() });
 export type Ping = z.infer<typeof Ping>;
 
+export const TypingStart = z.object({ channelId: z.string() });
+export type TypingStart = z.infer<typeof TypingStart>;
+
+export const TypingUpdate = z.object({
+  channelId: z.string(),
+  userId: z.string(),
+});
+export type TypingUpdate = z.infer<typeof TypingUpdate>;
+
 export const ServeParams = z
   .object({
     h: z.union([z.number(), z.null()]),
@@ -493,6 +502,8 @@ export const schemas = {
   ObjectWithId,
   Ping,
   ServeParams,
+  TypingStart,
+  TypingUpdate,
 };
 
 const endpoints = makeApi([
@@ -1214,6 +1225,7 @@ export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
 
 export const websocketCommands = {
   ping: Ping,
+  "typing.start": TypingStart,
 };
 
 export const websocketEvents = {
@@ -1233,6 +1245,7 @@ export const websocketEvents = {
   "spaces.onCreate": SpaceExt,
   "spaces.onDelete": SpaceExt,
   "spaces.onUpdate": SpaceExt,
+  "typing.onUpdate": TypingUpdate,
   "users.onCreate": UserExt,
   "users.onDelete": ObjectWithId,
   "users.onUpdate": UserExt,


### PR DESCRIPTION
## Summary

- Reconnects the typing indicator system to the WebSocket layer, replacing commented-out TODO code with a working `typing.start` → `typing.onUpdate` protocol
- Differentiates between humans ("is typing...") and bots ("is thinking...") using `user.category === 'BOT'`
- Adds a pulsing green dot next to bot members in the sidebar when they are actively thinking
- Extends the Rust bot SDK with `ctx.set_typing(channel_id)` so bots can signal typing status, backed by a new outbound WS command channel (`tokio::select!` in the event loop)
- Fixes `WebsocketApi.send()` type signature to accept data objects instead of Zod schemas

## Protocol

Ephemeral, no DB storage. Client sends `typing.start { channelId }` (throttled at 3s), server resolves channel→space and broadcasts `typing.onUpdate { channelId, userId }` to `space:{spaceId}`. Client auto-expires typers after 5s.

## Test plan

- [x] Open two browser tabs in the same space, type in one → see typing indicator in the other
- [x] Verify own typing is filtered out (no self-indicator)
- [x] Bot calling `ctx.set_typing(channel_id)` shows "BotName is thinking..." in the channel
- [x] Bot shows pulsing dot in the member list sidebar while thinking
- [x] Multiple simultaneous typers display correctly ("A, B are typing..." / "C is thinking...")
- [x] Typing indicator auto-expires after ~5s of inactivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)