### PR TITLE
Fix nginx regex location parsing error

### DIFF
--- a/apps/client/nginx.conf
+++ b/apps/client/nginx.conf
@@ -15,7 +15,7 @@ server {
   }
 
   # Hashed assets can be cached forever
-  location ~* \.[0-9a-f]{8,}\.(js|css)$ {
+  location ~* "\.[0-9a-f]{8,}\.(js|css)$" {
     root   /usr/share/nginx/html;
     add_header Cache-Control "public, max-age=31536000, immutable";
   }


### PR DESCRIPTION
## Summary

- Quotes the regex in the hashed asset `location` directive to prevent nginx from parsing `{8,}` as an unknown directive name, which caused nginx to fail to start

Fixes the remaining 502 after #694.

🤖 Generated with [Claude Code](https://claude.com/claude-code)