### PR TITLE
Fix invite modal not centered on screen

### DIFF
--- a/apps/client/src/components/modals/Invite.tsx
+++ b/apps/client/src/components/modals/Invite.tsx
@@ -1,4 +1,6 @@
-import { Button, DialogContent } from '@chakra-ui/react';
+import { Button } from '@chakra-ui/react';
+
+import { DialogContent } from '@/components/ui';
 import styled from '@emotion/styled';
 import { Invite, MikotoSpace } from '@mikoto-io/mikoto.js';
 import { useState } from 'react';


### PR DESCRIPTION
## Summary

- The invite modal imported `DialogContent` directly from `@chakra-ui/react` instead of the project's `@/components/ui` wrapper, which includes `Dialog.Positioner` for centering. This caused the modal to render at the bottom of the viewport instead of centered.

## Test plan

- [ ] Open a space context menu and click "Generate Invite"
- [ ] Generate an invite link and verify the modal is centered on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)