### PR TITLE
Add space visibility with handle-based public joining

### DIFF
--- a/apps/superego/api.json
+++ b/apps/superego/api.json
@@ -2856,6 +2856,16 @@
           },
           "type": {
             "$ref": "#/components/schemas/SpaceType"
+          },
+          "visibility": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpaceVisibility"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         }
       },
@@ -2887,8 +2897,25 @@
               "string",
               "null"
             ]
+          },
+          "visibility": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpaceVisibility"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         }
+      },
+      "SpaceVisibility": {
+        "type": "string",
+        "enum": [
+          "PRIVATE",
+          "PUBLIC"
+        ]
       },
       "Timestamp": {
         "type": "string",

--- a/apps/superego/migrations/20260330224504_add_space_is_public.sql
+++ b/apps/superego/migrations/20260330224504_add_space_is_public.sql
@@ -1,0 +1,3 @@
+CREATE TYPE "SpaceVisibility" AS ENUM ('PRIVATE', 'PUBLIC');
+
+ALTER TABLE "Space" ADD COLUMN visibility "SpaceVisibility";

--- a/apps/superego/schema.sql
+++ b/apps/superego/schema.sql
@@ -73,6 +73,18 @@ CREATE TYPE public."SpaceType" AS ENUM (
 ALTER TYPE public."SpaceType" OWNER TO postgres;
 
 --
+-- Name: SpaceVisibility; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public."SpaceVisibility" AS ENUM (
+    'PRIVATE',
+    'PUBLIC'
+);
+
+
+ALTER TYPE public."SpaceVisibility" OWNER TO postgres;
+
+--
 -- Name: UserCategory; Type: TYPE; Schema: public; Owner: postgres
 --
 
@@ -321,7 +333,8 @@ CREATE TABLE public."Space" (
     name character varying(64) NOT NULL,
     icon character varying(256),
     "ownerId" uuid,
-    type public."SpaceType" DEFAULT 'NONE'::public."SpaceType" NOT NULL
+    type public."SpaceType" DEFAULT 'NONE'::public."SpaceType" NOT NULL,
+    visibility public."SpaceVisibility"
 );
 
 

--- a/apps/superego/src/entities/space.rs
+++ b/apps/superego/src/entities/space.rs
@@ -14,6 +14,14 @@ db_enum!(
     }
 );
 
+db_enum!(
+    #[sqlx(type_name = "\"SpaceVisibility\"")]
+    pub enum SpaceVisibility {
+        Private,
+        Public,
+    }
+);
+
 entity!(
     /// # SpaceDataModel
     pub struct Space {
@@ -25,6 +33,8 @@ entity!(
         #[serde(rename = "type")]
         #[sqlx(rename = "type")]
         pub space_type: SpaceType,
+
+        pub visibility: Option<SpaceVisibility>,
     }
 );
 
@@ -47,6 +57,7 @@ pub struct SpacePatch {
     pub name: Option<String>,
     pub icon: Option<String>,
     pub owner_id: Option<Uuid>,
+    pub visibility: Option<SpaceVisibility>,
 }
 
 impl Space {
@@ -57,6 +68,7 @@ impl Space {
             icon: None,
             owner_id: Some(owner_id),
             space_type: SpaceType::None,
+            visibility: None,
         }
     }
 
@@ -92,8 +104,8 @@ impl Space {
                 VALUES (gen_random_uuid(), $1, '@everyone', -1, '0')
                 RETURNING "id"
             )
-            INSERT INTO "Space" ("id", "name", "icon", "ownerId", "type")
-            VALUES ($1, $2, $3, $4, $5)
+            INSERT INTO "Space" ("id", "name", "icon", "ownerId", "type", "visibility")
+            VALUES ($1, $2, $3, $4, $5, $6)
             "##,
         )
         .bind(self.id)
@@ -101,6 +113,7 @@ impl Space {
         .bind(&self.icon)
         .bind(self.owner_id)
         .bind(self.space_type)
+        .bind(self.visibility)
         .execute(db)
         .await?;
         Ok(())
@@ -116,7 +129,8 @@ impl Space {
             UPDATE "Space" SET
             "name" = COALESCE($2, "name"),
             "icon" = COALESCE($3, "icon"),
-            "ownerId" = COALESCE($4, "ownerId")
+            "ownerId" = COALESCE($4, "ownerId"),
+            "visibility" = COALESCE($5, "visibility")
             WHERE "id" = $1
             RETURNING *
             "##,
@@ -125,6 +139,7 @@ impl Space {
         .bind(&patch.name)
         .bind(&patch.icon)
         .bind(patch.owner_id)
+        .bind(patch.visibility)
         .fetch_optional(db)
         .await?
         .ok_or(Error::NotFound)?;

--- a/apps/superego/src/routes/spaces/mod.rs
+++ b/apps/superego/src/routes/spaces/mod.rs
@@ -9,7 +9,10 @@ use uuid::Uuid;
 
 use crate::{
     db::db,
-    entities::{Ban, Handle, Invite, MemberExt, MemberKey, Space, SpaceExt, SpacePatch, SpaceUser},
+    entities::{
+        Ban, Handle, Invite, MemberExt, MemberKey, Space, SpaceExt, SpacePatch, SpaceUser,
+        SpaceVisibility,
+    },
     error::Error,
     functions::{
         handle_verification::{
@@ -45,6 +48,7 @@ pub struct SpaceUpdatePayload {
     pub name: Option<String>,
     pub icon: Option<String>,
     pub handle: Option<String>,
+    pub visibility: Option<SpaceVisibility>,
 }
 
 impl SpaceUpdatePayload {
@@ -52,6 +56,7 @@ impl SpaceUpdatePayload {
         SpacePatch {
             name: self.name.clone(),
             icon: self.icon.clone(),
+            visibility: self.visibility,
             ..Default::default()
         }
     }
@@ -179,18 +184,33 @@ async fn delete(Load(space): Load<SpaceExt>, claims: Claims) -> Result<Json<()>,
     Ok(().into())
 }
 
-async fn invite_preview(Path(invite): Path<String>) -> Result<Json<SpaceExt>, Error> {
-    let invite = Invite::find_by_id(&invite, db()).await?;
+/// Resolve an invite string to a space. If the invite starts with `@`, treat it
+/// as a handle lookup for a public space; otherwise look up a traditional invite code.
+async fn resolve_invite(invite: &str) -> Result<Space, Error> {
+    if let Some(handle_str) = invite.strip_prefix('@') {
+        let handle = Handle::resolve(handle_str, db())
+            .await?
+            .ok_or(Error::NotFound)?;
+        let space_id = handle.space_id.ok_or(Error::NotFound)?;
+        let space = Space::find_by_id(space_id, db()).await?;
+        if space.visibility != Some(SpaceVisibility::Public) {
+            return Err(Error::forbidden("This space is not public"));
+        }
+        Ok(space)
+    } else {
+        let invite = Invite::find_by_id(invite, db()).await?;
+        Ok(Space::find_by_id(invite.space_id, db()).await?)
+    }
+}
 
-    let space = Space::find_by_id(invite.space_id, db()).await?;
+async fn invite_preview(Path(invite): Path<String>) -> Result<Json<SpaceExt>, Error> {
+    let space = resolve_invite(&invite).await?;
     let space = SpaceExt::dataload_one(space, db()).await?;
     Ok(space.into())
 }
 
 async fn join(Path(invite): Path<String>, claims: Claims) -> Result<Json<SpaceExt>, Error> {
-    let invite = Invite::find_by_id(&invite, db()).await?;
-
-    let space = Space::find_by_id(invite.space_id, db()).await?;
+    let space = resolve_invite(&invite).await?;
     let space = SpaceExt::dataload_one(space, db()).await?;
     join_space(&space, claims.sub.parse()?).await?;
     Ok(space.into())

--- a/crates/mikoto-client/src/generated.rs
+++ b/crates/mikoto-client/src/generated.rs
@@ -431,6 +431,8 @@ pub struct SpaceExt {
     pub owner_id: Option<Uuid>,
     pub roles: Vec<Role>,
     pub r#type: SpaceType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<SpaceVisibility>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -451,9 +453,27 @@ pub struct SpaceUpdatePayload {
     pub icon: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<SpaceVisibility>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SpaceVisibility {
+    #[serde(rename = "PRIVATE")]
+    Private,
+    #[serde(rename = "PUBLIC")]
+    Public,
 }
 
 pub type Timestamp = DateTime<Utc>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenPair {
+    pub access_token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -466,14 +486,6 @@ pub struct TypingStart {
 pub struct TypingUpdate {
     pub channel_id: String,
     pub user_id: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TokenPair {
-    pub access_token: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub refresh_token: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/packages/mikoto.js/src/api.gen.ts
+++ b/packages/mikoto.js/src/api.gen.ts
@@ -236,6 +236,9 @@ export type Role = z.infer<typeof Role>;
 export const SpaceType = z.enum(["NONE", "DM", "GROUP"]);
 export type SpaceType = z.infer<typeof SpaceType>;
 
+export const SpaceVisibility = z.enum(["PRIVATE", "PUBLIC"]);
+export type SpaceVisibility = z.infer<typeof SpaceVisibility>;
+
 export const SpaceExt = z.object({
   channels: z.array(Channel),
   handle: z.union([z.string(), z.null()]).optional(),
@@ -246,6 +249,7 @@ export const SpaceExt = z.object({
   ownerId: z.union([z.string(), z.null()]).optional(),
   roles: z.array(Role),
   type: SpaceType,
+  visibility: z.union([SpaceVisibility, z.null()]).optional(),
 });
 export type SpaceExt = z.infer<typeof SpaceExt>;
 
@@ -257,6 +261,7 @@ export const SpaceUpdatePayload = z
     handle: z.union([z.string(), z.null()]),
     icon: z.union([z.string(), z.null()]),
     name: z.union([z.string(), z.null()]),
+    visibility: z.union([SpaceVisibility, z.null()]),
   })
   .partial();
 export type SpaceUpdatePayload = z.infer<typeof SpaceUpdatePayload>;
@@ -420,6 +425,14 @@ export type ObjectWithId = z.infer<typeof ObjectWithId>;
 export const Ping = z.object({ message: z.string() });
 export type Ping = z.infer<typeof Ping>;
 
+export const ServeParams = z
+  .object({
+    h: z.union([z.number(), z.null()]),
+    w: z.union([z.number(), z.null()]),
+  })
+  .partial();
+export type ServeParams = z.infer<typeof ServeParams>;
+
 export const TypingStart = z.object({ channelId: z.string() });
 export type TypingStart = z.infer<typeof TypingStart>;
 
@@ -428,14 +441,6 @@ export const TypingUpdate = z.object({
   userId: z.string(),
 });
 export type TypingUpdate = z.infer<typeof TypingUpdate>;
-
-export const ServeParams = z
-  .object({
-    h: z.union([z.number(), z.null()]),
-    w: z.union([z.number(), z.null()]),
-  })
-  .partial();
-export type ServeParams = z.infer<typeof ServeParams>;
 
 export const schemas = {
   IndexResponse,
@@ -472,6 +477,7 @@ export const schemas = {
   Channel,
   Role,
   SpaceType,
+  SpaceVisibility,
   SpaceExt,
   SpaceCreatePayload,
   SpaceUpdatePayload,


### PR DESCRIPTION
## Summary

- Adds a nullable `SpaceVisibility` enum (`Private` | `Public`) column to the `Space` table. Null is treated as private, preserving backwards compatibility for all existing spaces.
- Public spaces can be joined via their handle using the existing `/join/:invite` endpoint with an `@` prefix (e.g. `/join/@my-space.mikoto.io`), removing the need for an invite code.
- The invite preview endpoint (`GET /join/:invite`) also supports `@handle` resolution, so public spaces can be previewed before joining.
- Space owners can toggle visibility through the existing space update endpoint.

## Test plan

- [ ] Create a space and verify it defaults to private (null visibility)
- [ ] Update a space's visibility to `Public` and confirm it persists
- [ ] Set a handle on a public space and join via `POST /join/@handle`
- [ ] Verify joining a private space by handle returns a 403
- [ ] Verify `GET /join/@handle` returns a preview for public spaces
- [ ] Verify existing invite code joins still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)