### PR TITLE
Make handles mandatory for users and regular spaces

### DIFF
--- a/apps/superego/api.json
+++ b/apps/superego/api.json
@@ -582,25 +582,6 @@
             }
           }
         }
-      },
-      "delete": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Release User Handle",
-        "operationId": "user.deleteHandle",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserExt"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/users/me/handle/verify": {
@@ -3124,7 +3105,7 @@
             }
           },
           "handle": {
-            "description": "The space's handle (if claimed)",
+            "description": "The space's handle (None only for DM/GROUP spaces)",
             "type": [
               "string",
               "null"
@@ -3362,6 +3343,7 @@
         "description": "User with extended data including handle",
         "type": "object",
         "required": [
+          "handle",
           "id",
           "name"
         ],
@@ -3389,11 +3371,8 @@
             ]
           },
           "handle": {
-            "description": "The user's handle (if claimed)",
-            "type": [
-              "string",
-              "null"
-            ]
+            "description": "The user's handle",
+            "type": "string"
           },
           "id": {
             "type": "string",

--- a/apps/superego/migrations/20260405214012_mandatory_handles.sql
+++ b/apps/superego/migrations/20260405214012_mandatory_handles.sql
@@ -64,7 +64,7 @@ BEGIN
 
         IF NOT done THEN
             INSERT INTO "Handle" (handle, "userId")
-            VALUES (base_handle || '-' || LEFT(id_hex, 12) || '.platform.mikoto.io', r.id);
+            VALUES (base_handle || '-' || id_hex || '.platform.mikoto.io', r.id);
         END IF;
     END LOOP;
 END $$;
@@ -132,7 +132,7 @@ BEGIN
 
         IF NOT done THEN
             INSERT INTO "Handle" (handle, "spaceId")
-            VALUES (base_handle || '-' || LEFT(id_hex, 12) || '.platform.mikoto.io', r.id);
+            VALUES (base_handle || '-' || id_hex || '.platform.mikoto.io', r.id);
         END IF;
     END LOOP;
 END $$;

--- a/apps/superego/migrations/20260405214012_mandatory_handles.sql
+++ b/apps/superego/migrations/20260405214012_mandatory_handles.sql
@@ -1,0 +1,219 @@
+-- Backfill handles for users who don't have one
+-- Uses sanitized name with UUID-based discriminators on conflict
+DO $$
+DECLARE
+    r RECORD;
+    base_handle TEXT;
+    id_hex TEXT;
+    done BOOLEAN;
+BEGIN
+    FOR r IN
+        SELECT u.id, u.name
+        FROM "User" u
+        WHERE NOT EXISTS (SELECT 1 FROM "Handle" h WHERE h."userId" = u.id)
+    LOOP
+        -- Sanitize: lowercase, replace invalid chars with hyphen, trim
+        base_handle := LOWER(r.name);
+        base_handle := REGEXP_REPLACE(base_handle, '[^a-z0-9_-]', '-', 'g');
+        base_handle := TRIM(BOTH '-' FROM TRIM(BOTH '_' FROM base_handle));
+        IF LENGTH(base_handle) < 2 THEN
+            base_handle := 'user';
+        END IF;
+        IF LENGTH(base_handle) > 60 THEN
+            base_handle := RTRIM(RTRIM(LEFT(base_handle, 60), '-'), '_');
+        END IF;
+
+        id_hex := REPLACE(r.id::text, '-', '');
+        done := FALSE;
+
+        -- Try base handle
+        BEGIN
+            INSERT INTO "Handle" (handle, "userId")
+            VALUES (base_handle || '.platform.mikoto.io', r.id);
+            done := TRUE;
+        EXCEPTION WHEN unique_violation THEN NULL;
+        END;
+
+        -- Try with progressively longer discriminators
+        IF NOT done THEN
+            BEGIN
+                INSERT INTO "Handle" (handle, "userId")
+                VALUES (base_handle || '-' || LEFT(id_hex, 3) || '.platform.mikoto.io', r.id);
+                done := TRUE;
+            EXCEPTION WHEN unique_violation THEN NULL;
+            END;
+        END IF;
+
+        IF NOT done THEN
+            BEGIN
+                INSERT INTO "Handle" (handle, "userId")
+                VALUES (base_handle || '-' || LEFT(id_hex, 4) || '.platform.mikoto.io', r.id);
+                done := TRUE;
+            EXCEPTION WHEN unique_violation THEN NULL;
+            END;
+        END IF;
+
+        IF NOT done THEN
+            BEGIN
+                INSERT INTO "Handle" (handle, "userId")
+                VALUES (base_handle || '-' || LEFT(id_hex, 6) || '.platform.mikoto.io', r.id);
+                done := TRUE;
+            EXCEPTION WHEN unique_violation THEN NULL;
+            END;
+        END IF;
+
+        IF NOT done THEN
+            INSERT INTO "Handle" (handle, "userId")
+            VALUES (base_handle || '-' || LEFT(id_hex, 12) || '.platform.mikoto.io', r.id);
+        END IF;
+    END LOOP;
+END $$;
+
+-- Backfill handles for regular spaces (not DM/GROUP) that don't have one
+DO $$
+DECLARE
+    r RECORD;
+    base_handle TEXT;
+    id_hex TEXT;
+    done BOOLEAN;
+BEGIN
+    FOR r IN
+        SELECT s.id, s.name
+        FROM "Space" s
+        WHERE s.type = 'NONE'
+          AND NOT EXISTS (SELECT 1 FROM "Handle" h WHERE h."spaceId" = s.id)
+    LOOP
+        base_handle := LOWER(r.name);
+        base_handle := REGEXP_REPLACE(base_handle, '[^a-z0-9_-]', '-', 'g');
+        base_handle := TRIM(BOTH '-' FROM TRIM(BOTH '_' FROM base_handle));
+        IF LENGTH(base_handle) < 2 THEN
+            base_handle := 'space';
+        END IF;
+        IF LENGTH(base_handle) > 60 THEN
+            base_handle := RTRIM(RTRIM(LEFT(base_handle, 60), '-'), '_');
+        END IF;
+
+        id_hex := REPLACE(r.id::text, '-', '');
+        done := FALSE;
+
+        BEGIN
+            INSERT INTO "Handle" (handle, "spaceId")
+            VALUES (base_handle || '.platform.mikoto.io', r.id);
+            done := TRUE;
+        EXCEPTION WHEN unique_violation THEN NULL;
+        END;
+
+        IF NOT done THEN
+            BEGIN
+                INSERT INTO "Handle" (handle, "spaceId")
+                VALUES (base_handle || '-' || LEFT(id_hex, 3) || '.platform.mikoto.io', r.id);
+                done := TRUE;
+            EXCEPTION WHEN unique_violation THEN NULL;
+            END;
+        END IF;
+
+        IF NOT done THEN
+            BEGIN
+                INSERT INTO "Handle" (handle, "spaceId")
+                VALUES (base_handle || '-' || LEFT(id_hex, 4) || '.platform.mikoto.io', r.id);
+                done := TRUE;
+            EXCEPTION WHEN unique_violation THEN NULL;
+            END;
+        END IF;
+
+        IF NOT done THEN
+            BEGIN
+                INSERT INTO "Handle" (handle, "spaceId")
+                VALUES (base_handle || '-' || LEFT(id_hex, 6) || '.platform.mikoto.io', r.id);
+                done := TRUE;
+            EXCEPTION WHEN unique_violation THEN NULL;
+            END;
+        END IF;
+
+        IF NOT done THEN
+            INSERT INTO "Handle" (handle, "spaceId")
+            VALUES (base_handle || '-' || LEFT(id_hex, 12) || '.platform.mikoto.io', r.id);
+        END IF;
+    END LOOP;
+END $$;
+
+-- Enforce one handle per user/space with unique partial indexes
+CREATE UNIQUE INDEX "Handle_userId_unique" ON "Handle" ("userId") WHERE "userId" IS NOT NULL;
+CREATE UNIQUE INDEX "Handle_spaceId_unique" ON "Handle" ("spaceId") WHERE "spaceId" IS NOT NULL;
+
+-- Constraint trigger: every User must have a handle (checked at commit time)
+CREATE OR REPLACE FUNCTION check_user_has_handle() RETURNS trigger AS $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM "Handle" WHERE "userId" = NEW.id) THEN
+        RAISE EXCEPTION 'User % must have a handle', NEW.id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER user_must_have_handle
+    AFTER INSERT ON "User"
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION check_user_has_handle();
+
+-- Constraint trigger: every regular Space (type='NONE') must have a handle
+CREATE OR REPLACE FUNCTION check_space_has_handle() RETURNS trigger AS $$
+BEGIN
+    IF NEW.type != 'NONE' THEN
+        RETURN NEW;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM "Handle" WHERE "spaceId" = NEW.id) THEN
+        RAISE EXCEPTION 'Space % must have a handle', NEW.id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER space_must_have_handle
+    AFTER INSERT ON "Space"
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION check_space_has_handle();
+
+-- Prevent deleting the last handle for a user
+CREATE OR REPLACE FUNCTION prevent_handle_orphan_user() RETURNS trigger AS $$
+BEGIN
+    IF OLD."userId" IS NOT NULL THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM "Handle"
+            WHERE "userId" = OLD."userId" AND handle != OLD.handle
+        ) THEN
+            -- Allow if the user is being deleted (CASCADE)
+            IF EXISTS (SELECT 1 FROM "User" WHERE id = OLD."userId") THEN
+                RAISE EXCEPTION 'Cannot remove the last handle for user %', OLD."userId";
+            END IF;
+        END IF;
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER prevent_handle_orphan_user
+    BEFORE DELETE ON "Handle"
+    FOR EACH ROW EXECUTE FUNCTION prevent_handle_orphan_user();
+
+-- Prevent deleting the last handle for a regular space
+CREATE OR REPLACE FUNCTION prevent_handle_orphan_space() RETURNS trigger AS $$
+BEGIN
+    IF OLD."spaceId" IS NOT NULL THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM "Handle"
+            WHERE "spaceId" = OLD."spaceId" AND handle != OLD.handle
+        ) THEN
+            -- Allow if the space is being deleted (CASCADE) or is DM/GROUP
+            IF EXISTS (SELECT 1 FROM "Space" WHERE id = OLD."spaceId" AND type = 'NONE') THEN
+                RAISE EXCEPTION 'Cannot remove the last handle for space %', OLD."spaceId";
+            END IF;
+        END IF;
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER prevent_handle_orphan_space
+    BEFORE DELETE ON "Handle"
+    FOR EACH ROW EXECUTE FUNCTION prevent_handle_orphan_space();

--- a/apps/superego/schema.sql
+++ b/apps/superego/schema.sql
@@ -96,6 +96,97 @@ CREATE TYPE public."UserCategory" AS ENUM (
 
 ALTER TYPE public."UserCategory" OWNER TO postgres;
 
+--
+-- Name: check_space_has_handle(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.check_space_has_handle() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF NEW.type != 'NONE' THEN
+        RETURN NEW;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM "Handle" WHERE "spaceId" = NEW.id) THEN
+        RAISE EXCEPTION 'Space % must have a handle', NEW.id;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION public.check_space_has_handle() OWNER TO postgres;
+
+--
+-- Name: check_user_has_handle(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.check_user_has_handle() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM "Handle" WHERE "userId" = NEW.id) THEN
+        RAISE EXCEPTION 'User % must have a handle', NEW.id;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION public.check_user_has_handle() OWNER TO postgres;
+
+--
+-- Name: prevent_handle_orphan_space(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.prevent_handle_orphan_space() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF OLD."spaceId" IS NOT NULL THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM "Handle"
+            WHERE "spaceId" = OLD."spaceId" AND handle != OLD.handle
+        ) THEN
+            -- Allow if the space is being deleted (CASCADE) or is DM/GROUP
+            IF EXISTS (SELECT 1 FROM "Space" WHERE id = OLD."spaceId" AND type = 'NONE') THEN
+                RAISE EXCEPTION 'Cannot remove the last handle for space %', OLD."spaceId";
+            END IF;
+        END IF;
+    END IF;
+    RETURN OLD;
+END;
+$$;
+
+
+ALTER FUNCTION public.prevent_handle_orphan_space() OWNER TO postgres;
+
+--
+-- Name: prevent_handle_orphan_user(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.prevent_handle_orphan_user() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF OLD."userId" IS NOT NULL THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM "Handle"
+            WHERE "userId" = OLD."userId" AND handle != OLD.handle
+        ) THEN
+            -- Allow if the user is being deleted (CASCADE)
+            IF EXISTS (SELECT 1 FROM "User" WHERE id = OLD."userId") THEN
+                RAISE EXCEPTION 'Cannot remove the last handle for user %', OLD."userId";
+            END IF;
+        END IF;
+    END IF;
+    RETURN OLD;
+END;
+$$;
+
+
+ALTER FUNCTION public.prevent_handle_orphan_user() OWNER TO postgres;
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -614,10 +705,24 @@ CREATE INDEX "Handle_spaceId_idx" ON public."Handle" USING btree ("spaceId");
 
 
 --
+-- Name: Handle_spaceId_unique; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX "Handle_spaceId_unique" ON public."Handle" USING btree ("spaceId") WHERE ("spaceId" IS NOT NULL);
+
+
+--
 -- Name: Handle_userId_idx; Type: INDEX; Schema: public; Owner: postgres
 --
 
 CREATE INDEX "Handle_userId_idx" ON public."Handle" USING btree ("userId");
+
+
+--
+-- Name: Handle_userId_unique; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX "Handle_userId_unique" ON public."Handle" USING btree ("userId") WHERE ("userId" IS NOT NULL);
 
 
 --
@@ -702,6 +807,34 @@ CREATE UNIQUE INDEX "_RoleToSpaceUser_AB_unique" ON public."_RoleToSpaceUser" US
 --
 
 CREATE INDEX "_RoleToSpaceUser_B_index" ON public."_RoleToSpaceUser" USING btree ("B");
+
+
+--
+-- Name: Handle prevent_handle_orphan_space; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER prevent_handle_orphan_space BEFORE DELETE ON public."Handle" FOR EACH ROW EXECUTE FUNCTION public.prevent_handle_orphan_space();
+
+
+--
+-- Name: Handle prevent_handle_orphan_user; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER prevent_handle_orphan_user BEFORE DELETE ON public."Handle" FOR EACH ROW EXECUTE FUNCTION public.prevent_handle_orphan_user();
+
+
+--
+-- Name: Space space_must_have_handle; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE CONSTRAINT TRIGGER space_must_have_handle AFTER INSERT ON public."Space" DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION public.check_space_has_handle();
+
+
+--
+-- Name: User user_must_have_handle; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE CONSTRAINT TRIGGER user_must_have_handle AFTER INSERT ON public."User" DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION public.check_user_has_handle();
 
 
 --

--- a/apps/superego/src/bin/seed.rs
+++ b/apps/superego/src/bin/seed.rs
@@ -12,7 +12,7 @@ use chrono::TimeDelta;
 use dotenvy::dotenv;
 use sqlx::PgPool;
 use superego::{
-    entities::{Account, Channel, ChannelType, Message, Role, SpaceUser},
+    entities::{Account, Channel, ChannelType, Handle, Message, Role, SpaceUser},
     error::Error as SuperegoError,
     functions::time::Timestamp,
 };
@@ -146,18 +146,29 @@ async fn create_user_with_account(pool: &PgPool, user: &TestUser) -> Result<(), 
         passhash,
     };
 
+    let mut tx = pool.begin().await?;
     account
-        .create_with_user(user.name, pool)
+        .create_with_user(user.name, &mut *tx)
         .await
         .map_err(|e| match e {
             SuperegoError::DatabaseError(e) => e,
             _ => sqlx::Error::Protocol("Unexpected error".to_string()),
         })?;
+    Handle::auto_assign_for_user(user.id, user.name, &mut *tx)
+        .await
+        .map_err(|e| match e {
+            SuperegoError::DatabaseError(e) => e,
+            _ => sqlx::Error::Protocol("Unexpected error".to_string()),
+        })?;
+    tx.commit().await?;
 
     Ok(())
 }
 
 async fn create_space(pool: &PgPool) -> Result<(), sqlx::Error> {
+    let space_name = "Test Community";
+    let mut tx = pool.begin().await?;
+
     // Create space directly without the default channel/role (we'll create our own)
     sqlx::query(
         r#"
@@ -166,10 +177,18 @@ async fn create_space(pool: &PgPool) -> Result<(), sqlx::Error> {
         "#,
     )
     .bind(TEST_SPACE_ID)
-    .bind("Test Community")
+    .bind(space_name)
     .bind(TEST_USERS[0].id)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
+
+    Handle::auto_assign_for_space(TEST_SPACE_ID, space_name, &mut *tx)
+        .await
+        .map_err(|e| match e {
+            SuperegoError::DatabaseError(e) => e,
+            _ => sqlx::Error::Protocol("Unexpected error".to_string()),
+        })?;
+    tx.commit().await?;
 
     Ok(())
 }

--- a/apps/superego/src/entities/handle.rs
+++ b/apps/superego/src/entities/handle.rs
@@ -378,6 +378,40 @@ impl Handle {
         Self::claim_for_user(handle, user_id, db).await
     }
 
+    /// Auto-generate a unique default handle for a space based on its name.
+    /// Tries the sanitized name first, then appends short discriminators on conflict.
+    pub async fn auto_assign_for_space(
+        space_id: Uuid,
+        name: &str,
+        db: &sqlx::PgPool,
+    ) -> Result<Self, Error> {
+        let base = Self::sanitize_username(name);
+
+        // Try the base username first
+        let handle = Self::make_default_handle(&base);
+        match Self::claim_for_space(handle, space_id, db).await {
+            Ok(h) => return Ok(h),
+            Err(Error::Miscallaneous { ref code, .. }) if code == "HandleTaken" => {}
+            Err(e) => return Err(e),
+        }
+
+        // Try with short discriminators derived from the space's UUID
+        let id_hex = space_id.as_simple().to_string();
+        for len in [3, 4, 6, 8] {
+            let discriminator = &id_hex[..len];
+            let handle = Self::make_default_handle(&format!("{}-{}", base, discriminator));
+            match Self::claim_for_space(handle, space_id, db).await {
+                Ok(h) => return Ok(h),
+                Err(Error::Miscallaneous { ref code, .. }) if code == "HandleTaken" => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        // Final fallback: full UUID prefix (very unlikely to reach here)
+        let handle = Self::make_default_handle(&format!("{}-{}", base, &id_hex[..12]));
+        Self::claim_for_space(handle, space_id, db).await
+    }
+
     /// Resolve a handle to its owner
     pub async fn resolve<'c, X: sqlx::PgExecutor<'c>>(
         handle: &str,
@@ -427,40 +461,6 @@ impl Handle {
         .await?;
 
         Ok(result)
-    }
-
-    /// Release a user's handle
-    pub async fn release_for_user<'c, X: sqlx::PgExecutor<'c>>(
-        user_id: Uuid,
-        db: X,
-    ) -> Result<bool, Error> {
-        let result = sqlx::query(
-            r#"
-            DELETE FROM "Handle" WHERE "userId" = $1
-            "#,
-        )
-        .bind(user_id)
-        .execute(db)
-        .await?;
-
-        Ok(result.rows_affected() > 0)
-    }
-
-    /// Release a space's handle
-    pub async fn release_for_space<'c, X: sqlx::PgExecutor<'c>>(
-        space_id: Uuid,
-        db: X,
-    ) -> Result<bool, Error> {
-        let result = sqlx::query(
-            r#"
-            DELETE FROM "Handle" WHERE "spaceId" = $1
-            "#,
-        )
-        .bind(space_id)
-        .execute(db)
-        .await?;
-
-        Ok(result.rows_affected() > 0)
     }
 
     /// Batch load handles for multiple users

--- a/apps/superego/src/entities/handle.rs
+++ b/apps/superego/src/entities/handle.rs
@@ -349,13 +349,13 @@ impl Handle {
     pub async fn auto_assign_for_user(
         user_id: Uuid,
         name: &str,
-        db: &sqlx::PgPool,
+        db: &mut sqlx::PgConnection,
     ) -> Result<Self, Error> {
         let base = Self::sanitize_username(name);
 
         // Try the base username first
         let handle = Self::make_default_handle(&base);
-        match Self::claim_for_user(handle, user_id, db).await {
+        match Self::claim_for_user(handle, user_id, &mut *db).await {
             Ok(h) => return Ok(h),
             Err(Error::Miscallaneous { ref code, .. }) if code == "HandleTaken" => {}
             Err(e) => return Err(e),
@@ -366,7 +366,7 @@ impl Handle {
         for len in [3, 4, 6, 8] {
             let discriminator = &id_hex[..len];
             let handle = Self::make_default_handle(&format!("{}-{}", base, discriminator));
-            match Self::claim_for_user(handle, user_id, db).await {
+            match Self::claim_for_user(handle, user_id, &mut *db).await {
                 Ok(h) => return Ok(h),
                 Err(Error::Miscallaneous { ref code, .. }) if code == "HandleTaken" => {}
                 Err(e) => return Err(e),
@@ -375,7 +375,7 @@ impl Handle {
 
         // Final fallback: full UUID prefix (very unlikely to reach here)
         let handle = Self::make_default_handle(&format!("{}-{}", base, &id_hex[..12]));
-        Self::claim_for_user(handle, user_id, db).await
+        Self::claim_for_user(handle, user_id, &mut *db).await
     }
 
     /// Auto-generate a unique default handle for a space based on its name.
@@ -383,13 +383,13 @@ impl Handle {
     pub async fn auto_assign_for_space(
         space_id: Uuid,
         name: &str,
-        db: &sqlx::PgPool,
+        db: &mut sqlx::PgConnection,
     ) -> Result<Self, Error> {
         let base = Self::sanitize_username(name);
 
         // Try the base username first
         let handle = Self::make_default_handle(&base);
-        match Self::claim_for_space(handle, space_id, db).await {
+        match Self::claim_for_space(handle, space_id, &mut *db).await {
             Ok(h) => return Ok(h),
             Err(Error::Miscallaneous { ref code, .. }) if code == "HandleTaken" => {}
             Err(e) => return Err(e),
@@ -400,7 +400,7 @@ impl Handle {
         for len in [3, 4, 6, 8] {
             let discriminator = &id_hex[..len];
             let handle = Self::make_default_handle(&format!("{}-{}", base, discriminator));
-            match Self::claim_for_space(handle, space_id, db).await {
+            match Self::claim_for_space(handle, space_id, &mut *db).await {
                 Ok(h) => return Ok(h),
                 Err(Error::Miscallaneous { ref code, .. }) if code == "HandleTaken" => {}
                 Err(e) => return Err(e),
@@ -409,7 +409,7 @@ impl Handle {
 
         // Final fallback: full UUID prefix (very unlikely to reach here)
         let handle = Self::make_default_handle(&format!("{}-{}", base, &id_hex[..12]));
-        Self::claim_for_space(handle, space_id, db).await
+        Self::claim_for_space(handle, space_id, &mut *db).await
     }
 
     /// Resolve a handle to its owner

--- a/apps/superego/src/entities/member.rs
+++ b/apps/superego/src/entities/member.rs
@@ -168,7 +168,7 @@ impl MemberExt {
                         .cloned()
                         .unwrap_or_else(|| UserExt {
                             base: User::ghost(),
-                            handle: None,
+                            handle: "ghost".to_string(),
                         }),
                     role_ids: role_ids
                         .get(&member_id)

--- a/apps/superego/src/entities/space.rs
+++ b/apps/superego/src/entities/space.rs
@@ -45,7 +45,7 @@ entity!(
 pub struct SpaceExt {
     #[serde(flatten)]
     pub base: Space,
-    /// The space's handle (if claimed)
+    /// The space's handle (None only for DM/GROUP spaces)
     pub handle: Option<String>,
     pub roles: Vec<Role>,
     pub channels: Vec<Channel>,

--- a/apps/superego/src/entities/user.rs
+++ b/apps/superego/src/entities/user.rs
@@ -244,7 +244,7 @@ impl RelationshipExt {
                     .cloned()
                     .unwrap_or_else(|| UserExt {
                         base: User::ghost(),
-                        handle: None,
+                        handle: "ghost".to_string(),
                     });
                 Self { base: rel, user }
             })
@@ -258,8 +258,8 @@ impl RelationshipExt {
 pub struct UserExt {
     #[serde(flatten)]
     pub base: User,
-    /// The user's handle (if claimed)
-    pub handle: Option<String>,
+    /// The user's handle
+    pub handle: String,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -327,9 +327,11 @@ impl User {
 
 impl UserExt {
     pub async fn from_user<'c, X: sqlx::PgExecutor<'c>>(user: User, db: X) -> Result<Self, Error> {
-        let handle = Handle::for_user(user.id, db).await?;
+        let handle = Handle::for_user(user.id, db)
+            .await?
+            .ok_or_else(|| Error::internal("User has no handle"))?;
         Ok(Self {
-            handle: handle.map(|h| h.handle),
+            handle: handle.handle,
             base: user,
         })
     }
@@ -344,7 +346,10 @@ impl UserExt {
         Ok(users
             .into_iter()
             .map(|user| {
-                let handle = handles.get(&user.id).cloned();
+                let handle = handles
+                    .get(&user.id)
+                    .cloned()
+                    .unwrap_or_else(|| "unknown".to_string());
                 Self { handle, base: user }
             })
             .collect())

--- a/apps/superego/src/entities/user.rs
+++ b/apps/superego/src/entities/user.rs
@@ -349,7 +349,7 @@ impl UserExt {
                 let handle = handles
                     .get(&user.id)
                     .cloned()
-                    .unwrap_or_else(|| "unknown".to_string());
+                    .unwrap_or_else(|| "ghost".to_string());
                 Self { handle, base: user }
             })
             .collect())

--- a/apps/superego/src/routes/account/register.rs
+++ b/apps/superego/src/routes/account/register.rs
@@ -49,10 +49,10 @@ pub async fn route(
         passhash: bcrypt::hash(body.password.clone(), bcrypt::DEFAULT_COST)?,
     };
 
-    account.create_with_user(&body.name, db()).await?;
-
-    // Auto-assign a unique default handle for the new user
-    let _ = Handle::auto_assign_for_user(account.id, &body.name, db()).await;
+    let mut tx = db().begin().await?;
+    account.create_with_user(&body.name, &mut *tx).await?;
+    Handle::auto_assign_for_user(account.id, &body.name, &mut *tx).await?;
+    tx.commit().await?;
 
     let (refresh, token) = RefreshToken::new(account.id);
     refresh.create(db()).await?;

--- a/apps/superego/src/routes/bots.rs
+++ b/apps/superego/src/routes/bots.rs
@@ -10,8 +10,8 @@ use uuid::Uuid;
 use crate::{
     db::db,
     entities::{
-        Bot, BotCreatedResponse, BotInfo, BotSpaceInfo, BotVisibility, MemberExt, MemberKey, Space,
-        SpaceExt, SpaceUser, TokenPair, User, UserPatch,
+        Bot, BotCreatedResponse, BotInfo, BotSpaceInfo, BotVisibility, Handle, MemberExt,
+        MemberKey, Space, SpaceExt, SpaceUser, TokenPair, User, UserPatch,
     },
     error::Error,
     functions::{
@@ -162,7 +162,10 @@ async fn create_bot(
         last_token_regenerated_at: None,
     };
 
-    bot.create_with_user(&body.name, db()).await?;
+    let mut tx = db().begin().await?;
+    bot.create_with_user(&body.name, &mut *tx).await?;
+    Handle::auto_assign_for_user(bot.id, &body.name, &mut *tx).await?;
+    tx.commit().await?;
 
     Ok(Json(BotCreatedResponse {
         id: bot.id,

--- a/apps/superego/src/routes/spaces/mod.rs
+++ b/apps/superego/src/routes/spaces/mod.rs
@@ -119,8 +119,9 @@ async fn create(
     claims: Claims,
     Json(body): Json<SpaceCreatePayload>,
 ) -> Result<Json<SpaceExt>, Error> {
-    let space = Space::new(body.name, claims.sub.parse()?);
+    let space = Space::new(body.name.clone(), claims.sub.parse()?);
     space.create(db()).await?;
+    Handle::auto_assign_for_space(space.id, &body.name, db()).await?;
     let space = SpaceExt::dataload_one(space, db()).await?;
     join_space(&space, claims.sub.parse()?).await?;
     Ok(space.into())
@@ -136,30 +137,25 @@ async fn update(
 
     // Update handle if provided
     if let Some(ref new_handle) = body.handle {
-        if new_handle.is_empty() {
-            // Empty string means release the handle
-            Handle::release_for_space(space_id, db()).await?;
+        // Determine the full handle
+        let full_handle = if !new_handle.contains('.') {
+            // Plain name -> create default handle (e.g., "rust-lang" -> "rust-lang.mikoto.io")
+            Handle::validate_username(new_handle)?;
+            Handle::make_default_handle(new_handle)
+        } else if Handle::is_default_handle(new_handle) {
+            // Already a default handle, validate and use as-is
+            Handle::validate(new_handle)?;
+            new_handle.clone()
         } else {
-            // Determine the full handle
-            let full_handle = if !new_handle.contains('.') {
-                // Plain name -> create default handle (e.g., "rust-lang" -> "rust-lang.mikoto.io")
-                Handle::validate_username(new_handle)?;
-                Handle::make_default_handle(new_handle)
-            } else if Handle::is_default_handle(new_handle) {
-                // Already a default handle, validate and use as-is
-                Handle::validate(new_handle)?;
-                new_handle.clone()
-            } else {
-                // Looks like a custom domain - must go through verification
-                return Err(Error::new(
-                    "CustomDomainRequiresVerification",
-                    axum::http::StatusCode::BAD_REQUEST,
-                    "Custom domain handles require verification. Use the /:spaceId/handle/verify endpoint to verify your domain.",
-                ));
-            };
+            // Looks like a custom domain - must go through verification
+            return Err(Error::new(
+                "CustomDomainRequiresVerification",
+                axum::http::StatusCode::BAD_REQUEST,
+                "Custom domain handles require verification. Use the /:spaceId/handle/verify endpoint to verify your domain.",
+            ));
+        };
 
-            Handle::change_space_handle(space_id, full_handle, db()).await?;
-        }
+        Handle::change_space_handle(space_id, full_handle, db()).await?;
     }
 
     let space = Space::find_by_id(space_id, db()).await?;

--- a/apps/superego/src/routes/spaces/mod.rs
+++ b/apps/superego/src/routes/spaces/mod.rs
@@ -120,8 +120,10 @@ async fn create(
     Json(body): Json<SpaceCreatePayload>,
 ) -> Result<Json<SpaceExt>, Error> {
     let space = Space::new(body.name.clone(), claims.sub.parse()?);
-    space.create(db()).await?;
-    Handle::auto_assign_for_space(space.id, &body.name, db()).await?;
+    let mut tx = db().begin().await?;
+    space.create(&mut *tx).await?;
+    Handle::auto_assign_for_space(space.id, &body.name, &mut *tx).await?;
+    tx.commit().await?;
     let space = SpaceExt::dataload_one(space, db()).await?;
     join_space(&space, claims.sub.parse()?).await?;
     Ok(space.into())

--- a/apps/superego/src/routes/users/mod.rs
+++ b/apps/superego/src/routes/users/mod.rs
@@ -1,4 +1,4 @@
-use aide::axum::routing::{delete_with, get_with, patch_with, post_with};
+use aide::axum::routing::{get_with, patch_with, post_with};
 use axum::Json;
 use chrono::Utc;
 use schemars::JsonSchema;
@@ -23,17 +23,7 @@ pub mod relations;
 
 async fn me(claim: Claims) -> Result<Json<UserExt>, Error> {
     let user = User::find_by_id(claim.sub.parse()?, db()).await?;
-    let mut user_ext = UserExt::from_user(user, db()).await?;
-
-    // Backfill: auto-assign a handle for users who don't have one yet
-    if user_ext.handle.is_none() {
-        if let Ok(h) =
-            Handle::auto_assign_for_user(user_ext.base.id, &user_ext.base.name, db()).await
-        {
-            user_ext.handle = Some(h.handle);
-        }
-    }
-
+    let user_ext = UserExt::from_user(user, db()).await?;
     Ok(user_ext.into())
 }
 
@@ -76,16 +66,6 @@ async fn set_handle(
     };
 
     Handle::change_user_handle(user_id, full_handle, db()).await?;
-
-    let user = User::find_by_id(user_id, db()).await?;
-    let user_ext = UserExt::from_user(user, db()).await?;
-    emit_event("users.onUpdate", &user_ext, &format!("user:{}", claim.sub)).await?;
-    Ok(user_ext.into())
-}
-
-async fn delete_handle(claim: Claims) -> Result<Json<UserExt>, Error> {
-    let user_id = claim.sub.parse()?;
-    Handle::release_for_user(user_id, db()).await?;
 
     let user = User::find_by_id(user_id, db()).await?;
     let user_ext = UserExt::from_user(user, db()).await?;
@@ -182,14 +162,6 @@ pub fn router() -> AppRouter<State> {
                 o.tag(TAG)
                     .id("user.setHandle")
                     .summary("Set or Change User Handle")
-            }),
-        )
-        .route(
-            "/me/handle",
-            delete_with(delete_handle, |o| {
-                o.tag(TAG)
-                    .id("user.deleteHandle")
-                    .summary("Release User Handle")
             }),
         )
         .route(


### PR DESCRIPTION
## Summary

- Handles are now required for all users and regular (non-DM/GROUP) spaces, enforced at the database level with constraint triggers
- Migration backfills handles for existing users/spaces using sanitized names with UUID-based discriminators on conflict
- Auto-assigns handles on space creation; removes ability to delete user/space handles
- `UserExt.handle` is now a non-optional `String` since every user is guaranteed to have one
- Removes `release_for_user` / `release_for_space` methods and the `DELETE /me/handle` endpoint
- Adds `auto_assign_for_space` to generate unique handles for new spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)