### PR TITLE
Fix upload endpoint returning doubled asset URLs

### DIFF
--- a/apps/content-proxy/src/routes/upload.rs
+++ b/apps/content-proxy/src/routes/upload.rs
@@ -129,6 +129,6 @@ pub async fn route(
     bucket().put_object(&store_path, &buf).await?;
 
     Ok(Json(UploadResponse {
-        url: format!("{}/{}", env().public_mediaserver_url, &store_path),
+        url: store_path,
     }))
 }


### PR DESCRIPTION
## Summary

- The upload endpoint was prepending `public_mediaserver_url` to the store path before returning it. Since consumers already resolve asset URLs by prepending the base URL, this caused the mediaserver URL to appear twice — breaking icon/avatar display.
- Now returns the relative store path instead, letting the client construct the full URL.

## Test plan

- [ ] Upload an avatar/icon and verify the resulting URL is correct (no doubled base URL)
- [ ] Verify existing stored assets still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)