### PR TITLE
Fix space icons on tabs not loading from CDN

### DIFF
--- a/apps/client/src/components/DockViewSurface.tsx
+++ b/apps/client/src/components/DockViewSurface.tsx
@@ -1,5 +1,6 @@
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { normalizeMediaUrl } from '@/components/atoms/Avatar';
 import {
   DockviewApi,
   DockviewDidDropEvent,
@@ -174,7 +175,7 @@ function CustomTabComponent(props: IDockviewPanelHeaderProps) {
               />
             ) : (
               <img
-                src={tabName.icon}
+                src={normalizeMediaUrl(tabName.icon as string)}
                 alt=""
                 style={{
                   width: '24px',


### PR DESCRIPTION
## Summary
- Space icons in DockView tabs were using raw relative paths (e.g. `spaceicon/...`) as the `<img>` src, instead of prepending the media server base URL
- Wrapped the icon src with `normalizeMediaUrl()` so tab icons load correctly from the CDN, matching how sidebar icons already work

## Test plan
- [ ] Open a space that has a custom icon
- [ ] Verify the icon appears correctly in the tab header
- [ ] Verify spaces without icons still show correctly (FontAwesome fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)