### PR TITLE
Add optimistic message updates for sent messages

### DIFF
--- a/apps/client/src/components/surfaces/Messages/Message/index.tsx
+++ b/apps/client/src/components/surfaces/Messages/Message/index.tsx
@@ -19,13 +19,14 @@ import { TypingDots } from '@/ui';
 
 import { Timestamp } from './Timestamp';
 
-const MessageContainer = styled.div<{ isSimple?: boolean }>`
+const MessageContainer = styled.div<{ isSimple?: boolean; pending?: boolean }>`
   margin: 0;
   display: flex;
   min-height: 20px;
   gap: 16px;
   padding: 2px 20px 6px;
   padding-top: ${(p) => (p.isSimple ? '2px' : '8px')};
+  opacity: ${(p) => (p.pending ? 0.5 : 1)};
   &:hover {
     background-color: rgba(0, 0, 0, 0.06);
   }
@@ -129,7 +130,7 @@ export const MessageItem = ({ message, isSimple }: MessageProps) => {
   ));
 
   return (
-    <MessageContainer isSimple={isSimple} onContextMenu={menu}>
+    <MessageContainer isSimple={isSimple} pending={message.pending} onContextMenu={menu}>
       {isSimple ? (
         <Box m={0} w={10} />
       ) : (

--- a/apps/client/src/components/surfaces/Messages/index.tsx
+++ b/apps/client/src/components/surfaces/Messages/index.tsx
@@ -188,12 +188,6 @@ function RealMessageView({ channel }: { channel: MikotoChannel }) {
     setMsgs((xs) => {
       if (xs === null) return null;
       setCurrentTypers((ts) => ts.filter((y) => y.userId !== x.author?.id));
-      // mikoto.client.messages
-      //   .ack({
-      //     channelId: channel.id,
-      //     timestamp: x.timestamp,
-      //   })
-      //   .then(() => {});
       if (channel.spaceId) {
         mikoto.rest['channels.acknowledge'](undefined, {
           params: {
@@ -203,6 +197,15 @@ function RealMessageView({ channel }: { channel: MikotoChannel }) {
         }).then(() => {});
       }
       setScrollToBottom(true);
+      // Replace optimistic message if one exists for this user
+      const optimisticIndex = xs.findIndex(
+        (m) => m.pending && m.authorId === x.authorId,
+      );
+      if (optimisticIndex !== -1) {
+        const updated = [...xs];
+        updated[optimisticIndex] = new MikotoMessage(x, mikoto);
+        return updated;
+      }
       return [...xs, new MikotoMessage(x, mikoto)];
     });
   };
@@ -330,6 +333,24 @@ function RealMessageView({ channel }: { channel: MikotoChannel }) {
                 setEditState(null);
                 await m.edit(msg);
               } else {
+                // Insert optimistic message immediately
+                const optimisticMsg = new MikotoMessage(
+                  {
+                    id: crypto.randomUUID(),
+                    channelId: channel.id,
+                    content: msg,
+                    authorId: mikoto.user.me?.id ?? null,
+                    author: mikoto.user.me ?? null,
+                    timestamp: new Date().toISOString(),
+                    editedTimestamp: null,
+                    attachments: [],
+                  },
+                  mikoto,
+                  true,
+                );
+                setMsgs((xs) => (xs ? [...xs, optimisticMsg] : null));
+                setScrollToBottom(true);
+
                 // Upload all files first
                 const attachments = await Promise.all(
                   files.map(async ({ file }) => {
@@ -343,7 +364,12 @@ function RealMessageView({ channel }: { channel: MikotoChannel }) {
                   }),
                 );
 
-                await channel.sendMessage(msg, attachments);
+                await channel.sendMessage(msg, attachments).catch(() => {
+                  // Remove optimistic message on failure
+                  setMsgs((xs) =>
+                    xs ? xs.filter((m) => m.id !== optimisticMsg.id) : null,
+                  );
+                });
               }
             }}
           />

--- a/packages/mikoto.js/src/managers/message.ts
+++ b/packages/mikoto.js/src/managers/message.ts
@@ -8,10 +8,12 @@ import type { MikotoChannel } from './channel';
 
 export class MikotoMessage extends ZSchema(MessageExt) {
   client!: MikotoClient;
+  pending?: boolean;
 
-  constructor(base: MessageExt, client: MikotoClient) {
+  constructor(base: MessageExt, client: MikotoClient, pending?: boolean) {
     super(base);
     this.client = ref(client);
+    if (pending) this.pending = true;
     return proxy(this);
   }
 


### PR DESCRIPTION
## Summary

- Sent messages now appear instantly in the message list at reduced opacity (50%), giving immediate visual feedback before server confirmation
- When the WebSocket `messages.onCreate` event arrives, the optimistic message is replaced in-place with the real server message
- If the send fails, the optimistic message is removed from the list

## Test plan

- [ ] Send a message and verify it appears immediately at lower opacity
- [ ] Verify the message transitions to full opacity once the server confirms
- [ ] Simulate a network failure and verify the optimistic message disappears
- [ ] Send multiple messages rapidly and verify correct ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)