### PR TITLE
Add DM search to command menu

### DIFF
--- a/apps/client/src/components/CommandMenu.tsx
+++ b/apps/client/src/components/CommandMenu.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@chakra-ui/react';
 import styled from '@emotion/styled';
-import { faHashtag } from '@fortawesome/free-solid-svg-icons';
+import { faEnvelope, faHashtag } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { MikotoChannel } from '@mikoto-io/mikoto.js';
 import { Command } from 'cmdk';
@@ -97,14 +97,18 @@ export function CommandMenuKit() {
   const setLeftSidebar = useSetAtom(treebarSpaceState);
   const tabkit = useTabkit();
 
-  // Subscribe to spaces for reactivity
+  // Subscribe to spaces and relationships for reactivity
   useSnapshot(mikoto.spaces);
+  useSnapshot(mikoto.relationships.cache);
 
   // Get all spaces
   const spaces = useMemo(() => {
     const spaceList = Array.from(mikoto.spaces.cache.values());
     return spaceList.filter((space) => space.type === 'NONE');
   }, [mikoto.spaces.cache.size]);
+
+  // Get DM friends
+  const dmFriends = mikoto.relationships.friends.filter((f) => f.channelId);
 
   // Toggle the menu when ⌘K is pressed
   useEffect(() => {
@@ -141,6 +145,16 @@ export function CommandMenuKit() {
     setOpen(false);
   };
 
+  const openDm = async (friend: (typeof dmFriends)[number]) => {
+    const channel = await friend.openDm();
+    setLeftSidebar({ kind: 'friends', key: 'friends' });
+    tabkit.openTab(
+      { kind: 'textChannel', key: channel.id, channelId: channel.id },
+      tabkit.getTabs().length > 0,
+    );
+    setOpen(false);
+  };
+
   return (
     <Dialog open={open} onOpenChange={setOpen} label="Global Command Menu">
       <Box bg="surface" rounded="md" maxW="60%" w="600px" maxH="400px">
@@ -148,6 +162,24 @@ export function CommandMenuKit() {
         <Box p={2}>
           <StyledList>
             <Command.Empty>No matching results</Command.Empty>
+
+            {dmFriends.length > 0 && (
+              <StyledGroup heading="Direct Messages">
+                {dmFriends.map((friend) => (
+                  <StyledItem
+                    key={friend.id}
+                    value={`dm ${friend.user.name}`}
+                    onSelect={() => openDm(friend)}
+                  >
+                    <FontAwesomeIcon
+                      icon={faEnvelope}
+                      style={{ opacity: 0.6, marginLeft: 4 }}
+                    />
+                    {friend.user.name}
+                  </StyledItem>
+                ))}
+              </StyledGroup>
+            )}
 
             <StyledGroup heading="Spaces">
               {spaces.map((space) => (


### PR DESCRIPTION
## Summary
- DM conversations are now searchable in the command menu (⌘K), so users can quickly jump to a DM by typing a friend's name
- Selecting a DM switches the sidebar to friends view and opens the channel tab

## Test plan
- [ ] Open command menu with ⌘K
- [ ] Verify DM friends appear under "Direct Messages" group
- [ ] Search by friend name and confirm filtering works
- [ ] Select a DM and verify sidebar switches to friends + channel opens
- [ ] Verify the section is hidden when no DMs exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)