### PR TITLE
Fix stale refresh token causing errors on idle tabs

### DIFF
--- a/packages/mikoto.js/src/AuthClient.ts
+++ b/packages/mikoto.js/src/AuthClient.ts
@@ -1,5 +1,4 @@
 import { pluginToken } from '@zodios/plugins';
-import { debounce } from 'lodash-es';
 
 import {
   Api,
@@ -30,32 +29,15 @@ export interface BotAuthClientOptions {
 export class AuthClient {
   api: Api;
   refreshToken?: string;
+  private getRefreshToken?: () => string;
   private setRefreshToken?: (token: string) => void;
-
-  // this prevents multiple refresh calls from happening at the same time
-  // when multiple requests are made in the same tick
-  debouncedRefresh = debounce(
-    async () => {
-      const res = await this.api['account.refresh']({
-        refreshToken: this.refreshToken ?? '',
-      });
-      if (res.refreshToken) {
-        this.refreshToken = res.refreshToken;
-        this.setRefreshToken?.(res.refreshToken);
-      }
-      return res.accessToken;
-    },
-    1000,
-    {
-      leading: true,
-      trailing: false,
-    },
-  );
+  private inflightRefresh?: Promise<string>;
 
   protected accessToken?: string;
 
   constructor(options: AuthClientOptions) {
     this.api = createApiClient(options.url, {});
+    this.getRefreshToken = options.refreshToken;
     this.refreshToken = options.refreshToken?.();
     this.setRefreshToken = options.setRefreshToken;
 
@@ -67,9 +49,53 @@ export class AuthClient {
   }
 
   async refresh(): Promise<string> {
-    const token = await this.debouncedRefresh();
-    this.accessToken = token;
-    return token;
+    // Deduplicate concurrent refresh calls by reusing the in-flight promise
+    if (this.inflightRefresh) {
+      return this.inflightRefresh;
+    }
+
+    this.inflightRefresh = this._doRefresh();
+    try {
+      const token = await this.inflightRefresh;
+      return token;
+    } finally {
+      this.inflightRefresh = undefined;
+    }
+  }
+
+  private async _doRefresh(): Promise<string> {
+    // Read the latest refresh token (e.g. from localStorage) in case
+    // another tab rotated it since we last cached it in memory
+    const currentToken =
+      this.getRefreshToken?.() ?? this.refreshToken ?? '';
+
+    try {
+      const res = await this.api['account.refresh']({
+        refreshToken: currentToken,
+      });
+      if (res.refreshToken) {
+        this.refreshToken = res.refreshToken;
+        this.setRefreshToken?.(res.refreshToken);
+      }
+      this.accessToken = res.accessToken;
+      return res.accessToken;
+    } catch (e) {
+      // If the token we used was already rotated by another tab,
+      // localStorage may now hold the newer token — retry once
+      const latestToken = this.getRefreshToken?.() ?? '';
+      if (latestToken && latestToken !== currentToken) {
+        const res = await this.api['account.refresh']({
+          refreshToken: latestToken,
+        });
+        if (res.refreshToken) {
+          this.refreshToken = res.refreshToken;
+          this.setRefreshToken?.(res.refreshToken);
+        }
+        this.accessToken = res.accessToken;
+        return res.accessToken;
+      }
+      throw e;
+    }
   }
 
   async register(payload: RegisterPayload) {

--- a/packages/mikoto.js/src/MikotoClient.ts
+++ b/packages/mikoto.js/src/MikotoClient.ts
@@ -52,6 +52,7 @@ export class MikotoClient {
 
   async connect() {
     this.token = await this.auth.refresh();
+    this.timeOfLastRefresh = new Date();
     const websocketUrl = new URL(this.options.url);
     websocketUrl.protocol = websocketUrl.protocol.replace('http', 'ws');
     this.ws = new WebsocketApi({


### PR DESCRIPTION
## Summary

- Fixes "invalid refresh token" error that occurs when a tab is left open for a long time and the user tries to send a message
- The root cause was a combination of: the refresh token being read from localStorage only once at construction (stale across tabs), and lodash's time-based debounce allowing race conditions with the backend's token rotation

## Changes

- **`AuthClient.ts`**: Replace lodash `debounce` with in-flight promise deduplication so concurrent refresh calls share one request. Read the refresh token getter on every attempt instead of caching once. Added retry-once fallback that re-reads localStorage if the token was rotated by another tab.
- **`MikotoClient.ts`**: Set `timeOfLastRefresh` in `connect()` to prevent a redundant double-refresh at startup.

## Test plan

- [ ] Open the app in two tabs, interact in both, verify no "invalid refresh token" errors
- [ ] Leave a tab idle for >1 hour, then send a message — should succeed without page refresh
- [ ] Verify login/logout flow still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)