### PR TITLE
Fix mention parsing inside links and URLs

### DIFF
--- a/apps/client/src/components/molecules/markdown/plugins.ts
+++ b/apps/client/src/components/molecules/markdown/plugins.ts
@@ -29,7 +29,7 @@ export function remarkMention() {
         (_: string, username: string) =>
           hNode('mention', { username }, `@${username}`),
       ],
-    ]);
+    ], { ignore: ['link', 'linkReference'] });
   };
 }
 
@@ -41,7 +41,7 @@ export function remarkEmoji() {
         (_: string, emoji: string) =>
           hNode('emoji-shortcode', { emoji }, `:${emoji}:`),
       ],
-    ]);
+    ], { ignore: ['link', 'linkReference'] });
   };
 }
 
@@ -52,7 +52,7 @@ export function remarkSpoiler() {
         /\|\|([\s\S]+?)\|\|(?!\|)/g,
         (_: string, content: string) => hNode('spoiler', { content }, content),
       ],
-    ]);
+    ], { ignore: ['link', 'linkReference'] });
   };
 }
 


### PR DESCRIPTION
## Summary

- Remark plugins (`remarkMention`, `remarkEmoji`, `remarkSpoiler`) now skip text inside link nodes
- Previously, URLs containing `@` or `:` were incorrectly parsed — e.g. `https://platform.mikoto.io/space/` would render `@mikoto` as a mention, breaking the link

## Details

Added `{ ignore: ['link', 'linkReference'] }` to all three `findAndReplace` calls so custom syntax is only matched in regular text, not inside auto-linked URLs or markdown links.

## Test plan

- [ ] Send a message with a URL containing `@` (e.g. `https://platform.mikoto.io/space/`) — should render as a plain link
- [ ] Send a message with a normal `@mention` outside a link — should still render as a mention
- [ ] Verify emoji shortcodes and spoiler syntax inside links are also left alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)