### PR TITLE
Misc UI improvements

### DIFF
--- a/apps/client/src/components/UserArea.tsx
+++ b/apps/client/src/components/UserArea.tsx
@@ -28,13 +28,6 @@ function UserAreaMenuItems() {
       </ContextMenu.Link>
       <ContextMenu.Link
         onClick={() => {
-          tabkit.openTab({ kind: 'palette', key: 'main' }, false);
-        }}
-      >
-        Open Palette
-      </ContextMenu.Link>
-      <ContextMenu.Link
-        onClick={() => {
           modal(<SetStatusModal />);
         }}
       >

--- a/apps/client/src/components/chakraTheme.tsx
+++ b/apps/client/src/components/chakraTheme.tsx
@@ -321,6 +321,10 @@ export const globalCss = css`
     font-family: var(--font-heading);
   }
 
+  p {
+    margin: 0;
+  }
+
   body {
     overscroll-behavior-x: none;
     overscroll-behavior-y: none;

--- a/apps/client/src/components/sidebars/SpaceSidebar/index.tsx
+++ b/apps/client/src/components/sidebars/SpaceSidebar/index.tsx
@@ -186,7 +186,9 @@ export function SpaceSidebar() {
       }}
     >
       <StyledSpaceSidebar onContextMenu={contextMenu}>
-        <StyledIconWrapper>
+        <StyledIconWrapper style={{
+          marginTop: '8px',
+        }}>
           <SpaceIconLike
             style={{
               background:

--- a/apps/client/src/components/sidebars/SpaceSidebar/index.tsx
+++ b/apps/client/src/components/sidebars/SpaceSidebar/index.tsx
@@ -194,7 +194,7 @@ export function SpaceSidebar() {
               background:
                 spaceId === null
                   ? 'linear-gradient(133deg, #2298ff 0%, rgba(59,108,255,1) 100%)'
-                  : undefined,
+                  : 'var(--chakra-colors-gray-700)',
             }}
             onClick={() => {
               setSpaceId(null);
@@ -203,7 +203,7 @@ export function SpaceSidebar() {
             <FontAwesomeIcon icon={faMikoto} fontSize="24px" />
           </SpaceIconLike>
         </StyledIconWrapper>
-        <Separator w={8} />
+        <Separator borderColor="gray.600" ml={3} width={9} borderWidth="1px" my={2}/>
 
         {spaceArray
           .filter((x) => x.type === 'NONE') // TODO: filter this on the server

--- a/apps/client/src/views/MainView.tsx
+++ b/apps/client/src/views/MainView.tsx
@@ -2,7 +2,6 @@ import { Box, Center } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 import {
   faBarsStaggered,
-  faGlobe,
   faMagnifyingGlass,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -290,13 +289,13 @@ const AppView = () => {
       <TopBar>
         <TopBarLeft>
           <UserAreaAvatar />
-          <TabBarButton
+          {/* <TabBarButton
             onClick={() => {
               tabkit.openTab({ kind: 'spaceExplorer', key: 'spaceExplorer' });
             }}
           >
             <FontAwesomeIcon icon={faGlobe} />
-          </TabBarButton>
+          </TabBarButton> */}
           <TabBarButton
             onClick={() => {
               setWorkspace((ws) => ({


### PR DESCRIPTION
## Summary
- Reset default `<p>` margin to 0 to fix spacing inconsistencies across the app
- Remove unused "Open Palette" menu item and space explorer button from the top bar
- Improve space sidebar styling: add top margin to icon, update home icon background color, and restyle the separator

## Test plan
- [ ] Verify space sidebar looks correct with updated icon and separator styling
- [ ] Confirm no regressions from removed palette/explorer UI elements
- [ ] Check that `<p>` margin reset doesn't break existing layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)