### PR TITLE
Bump Rust toolchain from 1.89 to 1.95

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ and upcoming features:
 Prerequisites:
 
 - Docker
-- Rust 1.93+
+- [Rustup](https://rustup.rs/)
 - [Proto](https://moonrepo.dev/proto) (tool manager, used to install moonrepo)
 - Just (task runner)
 

--- a/apps/content-proxy/Dockerfile
+++ b/apps/content-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.89-alpine AS builder
+FROM rust:1.95-alpine AS builder
 RUN apk add --no-cache musl-dev openssl-dev
 RUN apk update
 

--- a/apps/superego/Dockerfile
+++ b/apps/superego/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.89-alpine AS base
+FROM rust:1.95-alpine AS base
 RUN apk add --no-cache musl-dev openssl-dev
 RUN apk update
 RUN cargo install cargo-chef --version ^0.1

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.95.0"


### PR DESCRIPTION
## Summary

- Updates the Rust toolchain to 1.95.0 across `rust-toolchain.toml` and both Dockerfiles (superego, content-proxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)