### PR TITLE
Fix N+1 queries in bot listing and attachment creation

### DIFF
--- a/apps/superego/src/entities/bot.rs
+++ b/apps/superego/src/entities/bot.rs
@@ -1,9 +1,11 @@
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
+use std::collections::HashMap;
+
 use crate::{db_enum, db_find_by_id, entity, error::Error, model};
 
-use super::UserExt;
+use super::{hashmap_by_key, User, UserExt};
 
 db_enum!(
     #[sqlx(type_name = "\"BotVisibility\"")]
@@ -197,6 +199,26 @@ impl Bot {
         let mut info = self.to_info();
         info.user = user;
         Ok(info)
+    }
+
+    pub async fn to_infos_with_users<'c, X: sqlx::PgExecutor<'c> + Copy>(
+        bots: &[Self],
+        db: X,
+    ) -> Result<Vec<BotInfo>, Error> {
+        let bot_ids: Vec<Uuid> = bots.iter().map(|b| b.id).collect();
+        let users = User::dataload(bot_ids, db).await?;
+
+        let user_exts = UserExt::dataload(users.into_values().collect(), db).await?;
+        let user_ext_map: HashMap<Uuid, UserExt> = hashmap_by_key(user_exts, |u| u.base.id);
+
+        Ok(bots
+            .iter()
+            .map(|bot| {
+                let mut info = bot.to_info();
+                info.user = user_ext_map.get(&bot.id).cloned();
+                info
+            })
+            .collect())
     }
 
     pub async fn list_spaces<'c, X: sqlx::PgExecutor<'c>>(

--- a/apps/superego/src/entities/message_attachment.rs
+++ b/apps/superego/src/entities/message_attachment.rs
@@ -64,4 +64,48 @@ impl MessageAttachment {
         .await?;
         Ok(())
     }
+
+    pub async fn create_many<'c, X: sqlx::PgExecutor<'c>>(
+        attachments: &[Self],
+        db: X,
+    ) -> Result<(), Error> {
+        if attachments.is_empty() {
+            return Ok(());
+        }
+
+        let mut ids = Vec::with_capacity(attachments.len());
+        let mut message_ids = Vec::with_capacity(attachments.len());
+        let mut urls = Vec::with_capacity(attachments.len());
+        let mut filenames = Vec::with_capacity(attachments.len());
+        let mut content_types = Vec::with_capacity(attachments.len());
+        let mut sizes = Vec::with_capacity(attachments.len());
+        let mut orders = Vec::with_capacity(attachments.len());
+
+        for a in attachments {
+            ids.push(a.id);
+            message_ids.push(a.message_id);
+            urls.push(a.url.as_str());
+            filenames.push(a.filename.as_str());
+            content_types.push(a.content_type.as_str());
+            sizes.push(a.size);
+            orders.push(a.order);
+        }
+
+        sqlx::query(
+            r#"
+            INSERT INTO "MessageAttachment" ("id", "messageId", "url", "filename", "contentType", "size", "order")
+            SELECT * FROM UNNEST($1::uuid[], $2::uuid[], $3::text[], $4::text[], $5::text[], $6::int[], $7::int[])
+            "#,
+        )
+        .bind(&ids)
+        .bind(&message_ids)
+        .bind(&urls)
+        .bind(&filenames)
+        .bind(&content_types)
+        .bind(&sizes)
+        .bind(&orders)
+        .execute(db)
+        .await?;
+        Ok(())
+    }
 }

--- a/apps/superego/src/routes/bots.rs
+++ b/apps/superego/src/routes/bots.rs
@@ -174,10 +174,7 @@ async fn create_bot(
 
 async fn list_bots(account: Claims) -> Result<Json<Vec<BotInfo>>, Error> {
     let bots = Bot::list(Uuid::parse_str(&account.sub)?, db()).await?;
-    let mut infos = Vec::with_capacity(bots.len());
-    for bot in &bots {
-        infos.push(bot.to_info_with_user(db()).await?);
-    }
+    let infos = Bot::to_infos_with_users(&bots, db()).await?;
     Ok(Json(infos))
 }
 

--- a/apps/superego/src/routes/channels/messages.rs
+++ b/apps/superego/src/routes/channels/messages.rs
@@ -96,10 +96,13 @@ async fn send(
     message.create(db()).await?;
 
     // Create attachments if any
-    for (i, attachment_input) in body.attachments.into_iter().enumerate() {
-        let attachment = MessageAttachment::new(message.id, attachment_input, i as i32);
-        attachment.create(db()).await?;
-    }
+    let attachments: Vec<MessageAttachment> = body
+        .attachments
+        .into_iter()
+        .enumerate()
+        .map(|(i, input)| MessageAttachment::new(message.id, input, i as i32))
+        .collect();
+    MessageAttachment::create_many(&attachments, db()).await?;
 
     let message = MessageExt::dataload_one(message, db()).await?;
 


### PR DESCRIPTION
## Summary

- **Bot listing:** `list_bots` was calling `to_info_with_user()` per bot, issuing 2N database queries (user lookup + handle lookup). Added `to_infos_with_users()` that batch-loads all users and handles in 2 total queries.
- **Attachment creation:** `send` message handler inserted attachments one-by-one in a loop. Added `create_many()` using PostgreSQL `UNNEST` for a single batch insert.

## Test plan

- [ ] List bots for a user with multiple bots — verify all bot info (including user data) is returned correctly
- [ ] Send a message with multiple attachments — verify all attachments are created and returned
- [ ] Send a message with zero attachments — verify no error from empty batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)