### PR TITLE
Fix channel context menu crash and attachment URL handling

### DIFF
--- a/apps/client/src/components/surfaces/Explorer/ChannelContextMenu.tsx
+++ b/apps/client/src/components/surfaces/Explorer/ChannelContextMenu.tsx
@@ -184,7 +184,7 @@ export const ChannelContextMenu = ({ channel }: { channel: MikotoChannel }) => {
       >
         Channel Settings
       </ContextMenu.Link>
-      {channel.space!.member!.checkPermission(permissions.superuser) && (
+      {channel.space?.member?.checkPermission(permissions.superuser) && (
         <>
           <ContextMenu.Link
             onClick={() => {

--- a/apps/client/src/components/surfaces/Messages/Message/index.tsx
+++ b/apps/client/src/components/surfaces/Messages/Message/index.tsx
@@ -10,6 +10,7 @@ import { MikotoMessage } from '@mikoto-io/mikoto.js';
 import { atom, useSetAtom } from 'jotai';
 import { useSnapshot } from 'valtio/react';
 
+import { normalizeMediaUrl } from '@/components/atoms/Avatar';
 import { ContextMenu, useContextMenu } from '@/components/ContextMenu';
 import { MessageAvatar } from '@/components/atoms/MessageAvatar';
 import { Markdown } from '@/components/molecules/markdown';
@@ -178,7 +179,7 @@ export const MessageItem = ({ message, isSimple }: MessageProps) => {
               return (
                 <Link
                   key={attachment.id}
-                  href={attachment.url}
+                  href={normalizeMediaUrl(attachment.url)}
                   target="_blank"
                   rel="noopener noreferrer"
                   maxW={isImage ? '400px' : 'auto'}
@@ -186,7 +187,7 @@ export const MessageItem = ({ message, isSimple }: MessageProps) => {
                 >
                   {isImage ? (
                     <img
-                      src={attachment.url}
+                      src={normalizeMediaUrl(attachment.url)}
                       alt={attachment.filename}
                       style={{
                         maxWidth: '100%',


### PR DESCRIPTION
## Summary

- **Fix runtime crash in channel context menu**: Replace non-null assertions (`!`) with optional chaining (`?.`) when checking space member permissions, preventing crashes when `space` or `member` is null.
- **Fix attachment URLs not resolving correctly**: Apply `normalizeMediaUrl` to attachment URLs in messages so media hosted on the configured storage backend (e.g. MinIO) renders properly.

## Test plan
- [ ] Open a channel context menu and verify settings/delete options appear for superusers without errors
- [ ] Send a message with an image attachment and verify it displays correctly
- [ ] Send a message with a non-image attachment and verify the link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)