### PR TITLE
Redesign space icons with deterministic colors and heading font

### DIFF
--- a/apps/client/src/components/CommandMenu.tsx
+++ b/apps/client/src/components/CommandMenu.tsx
@@ -87,6 +87,7 @@ const SpaceIcon = styled.div<{ icon?: string }>`
   display: flex;
   align-items: center;
   justify-content: center;
+  font-family: var(--font-heading);
   font-size: 12px;
   font-weight: 600;
 `;

--- a/apps/client/src/components/atoms/SpaceIcon.tsx
+++ b/apps/client/src/components/atoms/SpaceIcon.tsx
@@ -7,6 +7,21 @@ interface SpaceIconProps {
   color?: string;
   fontSize?: string;
   active?: boolean | null;
+  spaceId?: string;
+}
+
+function hashString(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 31 + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function colorFromId(id: string): string {
+  const hash = hashString(id);
+  const hue = hash % 360;
+  return `oklch(0.55 0.25 ${hue})`;
 }
 
 // layout equivalent to a space icon
@@ -18,6 +33,7 @@ export const SpaceIconLike = styled.div`
   width: 40px;
   height: 40px;
 
+  font-family: var(--font-heading);
   font-size: 14px;
   cursor: pointer;
   border-radius: 4px;
@@ -28,6 +44,7 @@ const SpaceIcon = styled.div<{
   size?: string;
   fontSize?: string;
   active?: boolean | null;
+  bgColor?: string;
 }>`
   display: flex;
   align-items: center;
@@ -36,12 +53,18 @@ const SpaceIcon = styled.div<{
   width: ${(p) => p.size ?? '40px'};
   height: ${(p) => p.size ?? '40px'};
   background-color: ${(p) =>
-    p.active
-      ? 'var(--chakra-colors-gray-700)'
-      : 'var(--chakra-colors-surface)'};
+    p.icon
+      ? 'transparent'
+      : p.bgColor
+        ? p.bgColor
+        : p.active
+          ? 'var(--chakra-colors-gray-700)'
+          : 'var(--chakra-colors-surface)'};
   background-size: cover;
   background-image: ${(p) => (p.icon ? `url(${p.icon})` : 'none')};
-  font-size: 14px;
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 16px;
   cursor: pointer;
   border-radius: 4px;
 `;
@@ -61,6 +84,7 @@ export function StyledSpaceIcon({
   size,
   fontSize,
   active,
+  spaceId,
   ...rest
 }: SpaceIconProps & React.HTMLAttributes<HTMLDivElement>) {
   return (
@@ -70,6 +94,7 @@ export function StyledSpaceIcon({
         size={size}
         fontSize={fontSize}
         active={active}
+        bgColor={spaceId && !icon ? colorFromId(spaceId) : undefined}
         {...rest}
       />
     </SpaceIconOutline>

--- a/apps/client/src/components/sidebars/SpaceSidebar/index.tsx
+++ b/apps/client/src/components/sidebars/SpaceSidebar/index.tsx
@@ -80,6 +80,7 @@ function SidebarSpaceIcon({ space }: SidebarSpaceIconProps) {
         <StyledSpaceIcon
           active={isActive}
           size={ICON_SIZE}
+          spaceId={space.id}
           onContextMenu={contextMenu}
           icon={space.icon ? normalizeMediaUrl(space.icon) : undefined}
           onDoubleClick={() => {

--- a/apps/client/src/views/SpaceInviteView.tsx
+++ b/apps/client/src/views/SpaceInviteView.tsx
@@ -49,7 +49,7 @@ export function SpaceInviteViewInner() {
       <InvitationBox>
         {space ? (
           <Flex direction="column" alignItems="center" gap={4}>
-            <StyledSpaceIcon size="100px" icon={normalizeMediaUrl(space.icon)}>
+            <StyledSpaceIcon size="100px" spaceId={space.id} icon={normalizeMediaUrl(space.icon)}>
               {space.icon === null ? space.name[0] : ''}
             </StyledSpaceIcon>
             <Heading fontSize="32px" my={0}>


### PR DESCRIPTION
## Summary

- Space icons without a custom image now get a unique background color derived from the space ID, making them visually distinguishable at a glance
- Switched icon text to the heading font family with bolder weight for a more polished look
- Icons with a custom image use a transparent background instead of the surface color

## Test plan

- [ ] Verify spaces without icons show colored backgrounds that are consistent across reloads
- [ ] Verify spaces with custom icons still display correctly (transparent bg, no color overlay)
- [ ] Check the command menu, sidebar, and invite view all render consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)