### PR TITLE
Add context menu to channel panel header

### DIFF
--- a/apps/client/src/components/surfaces/Explorer/index.tsx
+++ b/apps/client/src/components/surfaces/Explorer/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {
   faChevronDown,
   faChevronRight,
+  faPlus,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { MikotoChannel, MikotoSpace } from '@mikoto-io/mikoto.js';
@@ -187,6 +188,8 @@ export function Explorer({ space }: { space: MikotoSpace }) {
   const nodeContextMenu = useContextMenuX();
   const [panels, setPanels] = useAtom(explorerPanelsState);
 
+  const channelHeaderContextMenu = useContextMenuX();
+
   // TODO: return loading indicator
   if (space === null) return null;
 
@@ -203,12 +206,28 @@ export function Explorer({ space }: { space: MikotoSpace }) {
             channelsCollapsed: !p.channelsCollapsed,
           }))
         }
+        onContextMenu={channelHeaderContextMenu(
+          <TreebarContextMenu space={space} />,
+        )}
       >
         <FontAwesomeIcon
           className="chevron"
           icon={panels.channelsCollapsed ? faChevronRight : faChevronDown}
         />
         Channels
+        <FontAwesomeIcon
+          icon={faPlus}
+          style={{
+            marginLeft: 'auto',
+            marginRight: '8px',
+            fontSize: '12px',
+            opacity: 0.6,
+          }}
+          onClick={(ev) => {
+            ev.stopPropagation();
+            channelHeaderContextMenu(<TreebarContextMenu space={space} />)(ev);
+          }}
+        />
       </PanelHeader>
 
       {panels.channelsCollapsed ? null : (


### PR DESCRIPTION
## Summary
- The "Channels" panel header in the explorer sidebar now supports right-click to open the channel context menu (Create Channel, Invite People, Search)
- Added a `+` icon on the right side of the header that opens the same context menu on click

## Test plan
- [ ] Right-click the "Channels" header and verify the context menu appears
- [ ] Click the `+` icon and verify the same context menu appears
- [ ] Verify clicking the header (not the `+`) still toggles collapse/expand
- [ ] Verify existing right-click on the channel list area still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)