### PR TITLE
Add @mention autocomplete to message editor

### DIFF
--- a/apps/client/src/components/molecules/markdown/plugins.ts
+++ b/apps/client/src/components/molecules/markdown/plugins.ts
@@ -25,7 +25,7 @@ export function remarkMention() {
   return (tree: TreeParam) => {
     findAndReplace(tree, [
       [
-        /@(\w+)/g,
+        /@([\w.]+)/g,
         (_: string, username: string) =>
           hNode('mention', { username }, `@${username}`),
       ],
@@ -61,7 +61,7 @@ const ESCAPE_PLACEHOLDER = '\u200C';
 
 // Matches code blocks/inline code (preserved as-is) or our custom escape sequences
 const ESCAPE_PREPROCESS_REGEX =
-  /(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]+`)|(?<!\\)\\(\|\|)|(?<!\\)\\(@|:)/g;
+  /(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]+`)|(?<!\\)\\(\|\|)|(?<!\\)\\(@[\w.]*|:)/g;
 
 /**
  * Pre-processes a markdown string so that \@, \:, and \|| escape sequences

--- a/apps/client/src/components/surfaces/Messages/MentionAutocomplete.tsx
+++ b/apps/client/src/components/surfaces/Messages/MentionAutocomplete.tsx
@@ -1,0 +1,209 @@
+import styled from '@emotion/styled';
+import type { MikotoMember } from '@mikoto-io/mikoto.js';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { BaseRange } from 'slate';
+import { Editor, Range, Transforms } from 'slate';
+import { ReactEditor } from 'slate-react';
+
+import { Avatar } from '@/components/atoms/Avatar';
+
+const Overlay = styled.div`
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  background-color: var(--chakra-colors-gray-800);
+  border: 1px solid var(--chakra-colors-gray-600);
+  border-radius: 8px;
+  padding: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+  width: 260px;
+  z-index: 10;
+  margin-bottom: 4px;
+`;
+
+const MentionItem = styled.div<{ active: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  background-color: ${(p) =>
+    p.active ? 'var(--chakra-colors-gray-600)' : 'transparent'};
+
+  &:hover {
+    background-color: var(--chakra-colors-gray-600);
+  }
+`;
+
+const Handle = styled.span`
+  color: var(--chakra-colors-gray-400);
+  font-size: 12px;
+`;
+
+function getMentionSearch(
+  editor: Editor,
+): { search: string; range: BaseRange } | null {
+  const { selection } = editor;
+  if (!selection || !Range.isCollapsed(selection)) return null;
+
+  const [start] = Range.edges(selection);
+  const beforeRange = {
+    anchor: { path: start.path, offset: 0 },
+    focus: start,
+  };
+
+  const beforeText = Editor.string(editor, beforeRange);
+  const atIndex = beforeText.lastIndexOf('@');
+  if (atIndex === -1) return null;
+
+  // @ must be at start or preceded by whitespace
+  if (atIndex > 0 && !/\s/.test(beforeText[atIndex - 1])) return null;
+
+  const search = beforeText.slice(atIndex + 1);
+  // Don't show autocomplete if there's a space after partial mention
+  if (search.includes(' ')) return null;
+
+  const range = {
+    anchor: { path: start.path, offset: atIndex },
+    focus: start,
+  };
+
+  return { search, range };
+}
+
+function filterMembers(members: MikotoMember[], search: string) {
+  const q = search.toLowerCase();
+  return members
+    .filter((m) => {
+      const handle = m.user.handle?.toLowerCase() ?? '';
+      const name = m.user.name.toLowerCase();
+      return handle.includes(q) || name.includes(q);
+    })
+    .slice(0, 10);
+}
+
+interface UseMentionAutocompleteOptions {
+  editor: Editor & ReactEditor;
+  members: MikotoMember[];
+}
+
+export function useMentionAutocomplete({
+  editor,
+  members,
+}: UseMentionAutocompleteOptions) {
+  const [mentionState, setMentionState] = useState<{
+    search: string;
+    range: BaseRange;
+  } | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const activeIndexRef = useRef(0);
+
+  const filtered = mentionState ? filterMembers(members, mentionState.search) : [];
+  const isOpen = mentionState !== null && filtered.length > 0;
+
+  // Keep ref in sync
+  activeIndexRef.current = activeIndex;
+
+  // Reset index when search changes
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [mentionState?.search]);
+
+  const updateMentionState = useCallback(() => {
+    try {
+      const result = getMentionSearch(editor);
+      setMentionState(result);
+    } catch {
+      setMentionState(null);
+    }
+  }, [editor]);
+
+  // Track editor changes via DOM observation
+  useEffect(() => {
+    let editorEl: HTMLElement;
+    try {
+      editorEl = ReactEditor.toDOMNode(editor, editor);
+    } catch {
+      return;
+    }
+
+    const observer = new MutationObserver(updateMentionState);
+    observer.observe(editorEl, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+    document.addEventListener('selectionchange', updateMentionState);
+
+    return () => {
+      observer.disconnect();
+      document.removeEventListener('selectionchange', updateMentionState);
+    };
+  }, [editor, updateMentionState]);
+
+  const insertMention = useCallback(
+    (member: MikotoMember) => {
+      if (!mentionState) return;
+      const handle = member.user.handle ?? member.user.name;
+      Transforms.select(editor, mentionState.range);
+      Transforms.insertText(editor, `@${handle} `);
+      setMentionState(null);
+    },
+    [editor, mentionState],
+  );
+
+  const onKeyDown = useCallback(
+    (ev: React.KeyboardEvent): boolean => {
+      if (!isOpen) return false;
+
+      if (ev.key === 'ArrowUp') {
+        ev.preventDefault();
+        setActiveIndex((i) => (i <= 0 ? filtered.length - 1 : i - 1));
+        return true;
+      }
+      if (ev.key === 'ArrowDown') {
+        ev.preventDefault();
+        setActiveIndex((i) => (i >= filtered.length - 1 ? 0 : i + 1));
+        return true;
+      }
+      if (ev.key === 'Tab' || ev.key === 'Enter') {
+        ev.preventDefault();
+        const member = filtered[activeIndexRef.current];
+        if (member) insertMention(member);
+        return true;
+      }
+      if (ev.key === 'Escape') {
+        ev.preventDefault();
+        setMentionState(null);
+        return true;
+      }
+      return false;
+    },
+    [isOpen, filtered, insertMention],
+  );
+
+  const overlay = isOpen ? (
+    <Overlay
+      onMouseDown={(e) => {
+        e.preventDefault();
+      }}
+    >
+      {filtered.map((member, i) => (
+        <MentionItem
+          key={member.userId}
+          active={i === activeIndex}
+          onClick={() => insertMention(member)}
+        >
+          <Avatar src={member.user.avatar} userId={member.userId} size={24} />
+          <span>{member.name ?? member.user.name}</span>
+          {member.user.handle && <Handle>@{member.user.handle}</Handle>}
+        </MentionItem>
+      ))}
+    </Overlay>
+  ) : null;
+
+  return { overlay, onKeyDown };
+}

--- a/apps/client/src/components/surfaces/Messages/MessageEditor.tsx
+++ b/apps/client/src/components/surfaces/Messages/MessageEditor.tsx
@@ -6,6 +6,7 @@ import {
   faPaperPlane,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { MikotoMember } from '@mikoto-io/mikoto.js';
 import useResizeObserver from '@react-hook/resize-observer';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { Suspense, lazy, useEffect, useMemo, useRef, useState } from 'react';
@@ -18,6 +19,7 @@ import { contextMenuState } from '@/components/ContextMenu';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
 import { messageEditState } from './Message';
+import { useMentionAutocomplete } from './MentionAutocomplete';
 
 const EmojiPicker = lazy(() => import('./EmojiPicker'));
 
@@ -78,6 +80,7 @@ interface MessageEditorProps {
   onSubmit: (content: string, files: FileUpload[]) => void;
   onTyping?: () => void;
   onResize?: () => void;
+  members?: MikotoMember[];
 }
 
 const EditorButtons = styled.div`
@@ -228,6 +231,7 @@ export function MessageEditor({
   onSubmit,
   onTyping,
   onResize,
+  members = [],
 }: MessageEditorProps) {
   const currentEditState = useAtomValue(messageEditState);
   const setEditState = useSetAtom(messageEditState);
@@ -255,6 +259,9 @@ export function MessageEditor({
       ),
     [],
   );
+
+  const { overlay: mentionOverlay, onKeyDown: mentionKeyDown } =
+    useMentionAutocomplete({ editor, members });
 
   const setContextMenu = useSetAtom(contextMenuState);
   const ref = useRef<HTMLDivElement>(null);
@@ -325,6 +332,7 @@ export function MessageEditor({
           </UploadSection>
         )}
         <EditableContainer ref={ref}>
+          {mentionOverlay}
           <Slate
             editor={editor}
             initialValue={editorValue}
@@ -333,6 +341,8 @@ export function MessageEditor({
             <StyledEditable
               placeholder={placeholder}
               onKeyDown={(ev) => {
+                if (mentionKeyDown(ev)) return;
+
                 if (isMobile) {
                   onTyping?.();
                   return;

--- a/apps/client/src/components/surfaces/Messages/index.tsx
+++ b/apps/client/src/components/surfaces/Messages/index.tsx
@@ -10,6 +10,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import throttle from 'lodash/throttle';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
+import { useSnapshot } from 'valtio';
 
 import { Surface } from '@/components/Surface';
 import { TabName } from '@/components/tabs';
@@ -110,6 +111,11 @@ function RealMessageView({ channel }: { channel: MikotoChannel }) {
 
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const mikoto = useMikoto();
+  const membersCache = useSnapshot(channel.space?.members.cache ?? new Map());
+  const spaceMembers = useMemo(
+    () => Array.from(membersCache.values()),
+    [membersCache],
+  );
 
   // For DM channels, resolve the display name from the relationship
   const dmRelation = !channel.spaceId
@@ -314,6 +320,7 @@ function RealMessageView({ channel }: { channel: MikotoChannel }) {
           <MessageEditor
             placeholder={`Message #${channel.name}`}
             key={currentEditState?.id ?? 'base'}
+            members={spaceMembers}
             onTyping={() => {
               typing();
             }}


### PR DESCRIPTION
## Summary

- Adds an @mention autocomplete popup to the message editor that suggests space members as you type
- Filters members by display name and handle, navigable via keyboard (arrow keys, Tab/Enter to select, Escape to dismiss)
- Updates the markdown mention regex to support dots in usernames (e.g. `@user.name`)

## Test plan

- [ ] Type `@` in the message editor and verify the autocomplete popup appears with member suggestions
- [ ] Verify filtering works by typing partial names/handles
- [ ] Verify keyboard navigation (Up/Down arrows, Enter/Tab to select, Escape to close)
- [ ] Verify clicking a suggestion inserts the mention
- [ ] Verify mentions with dots in handles render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)