### PR TITLE
Bump LiveKit server to v1.11.0 and deduplicate tslib

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - '35104:9001'
     restart: always
   livekit:
-    image: 'livekit/livekit-server:v1.8.3'
+    image: 'livekit/livekit-server:v1.11.0'
     command: '--keys "devkey: secret1234567890abcdefghijklmnopqrtsuvwxyz"'
     ports:
       - '35105:7880'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2233,7 +2233,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.17.13':
     resolution: {integrity: sha512-n13yxOmI3I0JidzMdFCH68tYKGDtK4XlDFk1vysZX7AIRKeDVRsSbHhma5jCla2bDt25RKmJBHA9KtzielwzAA==}
@@ -10123,9 +10123,6 @@ packages:
   tslib@2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
 
-  tslib@2.7.0:
-    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -12162,13 +12159,13 @@ snapshots:
     dependencies:
       '@dnd-kit/geometry': 0.3.2
       '@dnd-kit/state': 0.3.2
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@dnd-kit/collision@0.3.2':
     dependencies:
       '@dnd-kit/abstract': 0.3.2
       '@dnd-kit/geometry': 0.3.2
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@dnd-kit/dom@0.3.2':
     dependencies:
@@ -12176,12 +12173,12 @@ snapshots:
       '@dnd-kit/collision': 0.3.2
       '@dnd-kit/geometry': 0.3.2
       '@dnd-kit/state': 0.3.2
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@dnd-kit/geometry@0.3.2':
     dependencies:
       '@dnd-kit/state': 0.3.2
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@dnd-kit/react@0.3.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -12190,12 +12187,12 @@ snapshots:
       '@dnd-kit/state': 0.3.2
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@dnd-kit/state@0.3.2':
     dependencies:
       '@preact/signals-core': 1.13.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@effect/schema@0.69.0(effect@3.5.7)':
     dependencies:
@@ -13274,7 +13271,7 @@ snapshots:
       password-prompt: 1.1.3
       sudo-prompt: 8.2.5
       tmp: 0.0.33
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
@@ -13526,7 +13523,7 @@ snapshots:
       fs-extra: 10.1.0
       http-call: 5.3.0
       semver: 7.6.3
-      tslib: 2.7.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -14188,7 +14185,7 @@ snapshots:
       strip-ansi: 6.0.1
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
-      tslib: 2.7.0
+      tslib: 2.8.1
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
@@ -14218,7 +14215,7 @@ snapshots:
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
       ts-node: 10.9.2(@types/node@22.7.2)(typescript@5.6.2)
-      tslib: 2.7.0
+      tslib: 2.8.1
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
@@ -15203,7 +15200,7 @@ snapshots:
 
   '@swc/helpers@0.5.13':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@szmarczak/http-timer@4.0.6':
     dependencies:
@@ -16450,7 +16447,7 @@ snapshots:
 
   aria-hidden@1.2.4:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -16536,7 +16533,7 @@ snapshots:
 
   ast-types@0.15.2:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   astral-regex@1.0.0:
     optional: true
@@ -16566,7 +16563,7 @@ snapshots:
 
   autolinker@3.16.2:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -18667,7 +18664,7 @@ snapshots:
 
   file-selector@0.6.0:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   filelist@1.0.4:
     dependencies:
@@ -18795,7 +18792,7 @@ snapshots:
     dependencies:
       motion-dom: 12.34.0
       motion-utils: 12.29.2
-      tslib: 2.7.0
+      tslib: 2.8.1
     optionalDependencies:
       '@emotion/is-prop-valid': 1.4.0
       react: 19.2.4
@@ -19163,12 +19160,12 @@ snapshots:
   graphql-tag@2.12.6(graphql@15.8.0):
     dependencies:
       graphql: 15.8.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   graphql-tag@2.12.6(graphql@16.8.1):
     dependencies:
       graphql: 16.8.1
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   graphql@15.8.0: {}
 
@@ -22315,7 +22312,7 @@ snapshots:
     dependencies:
       react: 19.2.4
       react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
-      tslib: 2.7.0
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -22324,7 +22321,7 @@ snapshots:
       react: 19.2.4
       react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
       react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
-      tslib: 2.7.0
+      tslib: 2.8.1
       use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
       use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
@@ -22346,7 +22343,7 @@ snapshots:
     dependencies:
       get-nonce: 1.0.1
       react: 19.2.4
-      tslib: 2.7.0
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -22435,7 +22432,7 @@ snapshots:
       ast-types: 0.15.2
       esprima: 4.0.1
       source-map: 0.6.1
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   rechoir@0.8.0:
     dependencies:
@@ -22733,7 +22730,7 @@ snapshots:
 
   rxjs@7.8.2:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -23397,7 +23394,7 @@ snapshots:
 
   tanu@0.1.13:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
       typescript: 4.9.5
 
   tar@6.1.13:
@@ -23623,8 +23620,6 @@ snapshots:
       typescript: 5.6.2
 
   tslib@2.4.1: {}
-
-  tslib@2.7.0: {}
 
   tslib@2.8.1: {}
 
@@ -23890,7 +23885,7 @@ snapshots:
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       react: 19.2.4
-      tslib: 2.7.0
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -23902,7 +23897,7 @@ snapshots:
     dependencies:
       detect-node-es: 1.1.0
       react: 19.2.4
-      tslib: 2.7.0
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 


### PR DESCRIPTION
## Summary
- Bumps the local dev LiveKit server from v1.8.3 to v1.11.0 to match the livekit-client v2 upgrade in #725
- Deduplicates `tslib` in pnpm-lock.yaml, consolidating `2.7.0` references to `2.8.1`
- Fixes a malformed `engines` field in the lockfile for `@expo/bunyan`

## Why
The previous LiveKit server version was incompatible with the v2 client SDK. The tslib dedup is cleanup from the dependency bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)