### PR TITLE
Add :emoji: autocomplete to message editor

### DIFF
--- a/apps/client/src/components/surfaces/Messages/EmojiAutocomplete.tsx
+++ b/apps/client/src/components/surfaces/Messages/EmojiAutocomplete.tsx
@@ -1,0 +1,263 @@
+import styled from '@emotion/styled';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { BaseRange } from 'slate';
+import { Editor, Range, Transforms } from 'slate';
+import { ReactEditor } from 'slate-react';
+
+const Overlay = styled.div`
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  background-color: var(--chakra-colors-gray-800);
+  border: 1px solid var(--chakra-colors-gray-600);
+  border-radius: 8px;
+  padding: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+  width: 320px;
+  z-index: 10;
+  margin-bottom: 4px;
+`;
+
+const EmojiItem = styled.div<{ active: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  background-color: ${(p) =>
+    p.active ? 'var(--chakra-colors-gray-600)' : 'transparent'};
+
+  &:hover {
+    background-color: var(--chakra-colors-gray-600);
+  }
+`;
+
+const Native = styled.span`
+  font-size: 18px;
+  width: 24px;
+  text-align: center;
+  flex-shrink: 0;
+`;
+
+const Shortcode = styled.span`
+  color: var(--chakra-colors-gray-400);
+  font-size: 12px;
+  margin-left: auto;
+`;
+
+const Name = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+type EmojiEntry = {
+  id: string;
+  name: string;
+  native: string;
+  keywords: string[];
+};
+
+let emojiListCache: EmojiEntry[] | null = null;
+let loadingPromise: Promise<EmojiEntry[]> | null = null;
+
+function loadEmojis(): Promise<EmojiEntry[]> {
+  if (emojiListCache) return Promise.resolve(emojiListCache);
+  if (!loadingPromise) {
+    loadingPromise = import('@emoji-mart/data/sets/14/twitter.json').then(
+      (mod) => {
+        const data: any = (mod as any).default ?? mod;
+        const list: EmojiEntry[] = Object.values<any>(data.emojis).map((e) => ({
+          id: e.id,
+          name: e.name,
+          native: e.skins?.[0]?.native ?? '',
+          keywords: e.keywords ?? [],
+        }));
+        emojiListCache = list;
+        return list;
+      },
+    );
+  }
+  return loadingPromise;
+}
+
+function getEmojiSearch(
+  editor: Editor,
+): { search: string; range: BaseRange } | null {
+  const { selection } = editor;
+  if (!selection || !Range.isCollapsed(selection)) return null;
+
+  const [start] = Range.edges(selection);
+  const beforeRange = {
+    anchor: { path: start.path, offset: 0 },
+    focus: start,
+  };
+
+  const beforeText = Editor.string(editor, beforeRange);
+  const colonIndex = beforeText.lastIndexOf(':');
+  if (colonIndex === -1) return null;
+
+  // : must be at start or preceded by whitespace
+  if (colonIndex > 0 && !/\s/.test(beforeText[colonIndex - 1])) return null;
+
+  const search = beforeText.slice(colonIndex + 1);
+  // Only accept valid shortcode characters so smileys like ":D " or colons
+  // used as punctuation don't keep the popup open.
+  if (!/^[a-z0-9_+-]*$/i.test(search)) return null;
+  // Require at least 2 chars to avoid opening on bare `:` or single letters.
+  if (search.length < 2) return null;
+
+  const range = {
+    anchor: { path: start.path, offset: colonIndex },
+    focus: start,
+  };
+
+  return { search, range };
+}
+
+function filterEmojis(emojis: EmojiEntry[], search: string): EmojiEntry[] {
+  const q = search.toLowerCase();
+  const startsWith: EmojiEntry[] = [];
+  const idIncludes: EmojiEntry[] = [];
+  const keywordIncludes: EmojiEntry[] = [];
+  for (const e of emojis) {
+    if (e.id.startsWith(q)) {
+      startsWith.push(e);
+    } else if (e.id.includes(q)) {
+      idIncludes.push(e);
+    } else if (e.keywords.some((k) => k.includes(q))) {
+      keywordIncludes.push(e);
+    }
+    if (startsWith.length >= 10) break;
+  }
+  return [...startsWith, ...idIncludes, ...keywordIncludes].slice(0, 10);
+}
+
+interface UseEmojiAutocompleteOptions {
+  editor: Editor & ReactEditor;
+}
+
+export function useEmojiAutocomplete({ editor }: UseEmojiAutocompleteOptions) {
+  const [emojis, setEmojis] = useState<EmojiEntry[]>([]);
+  const [emojiState, setEmojiState] = useState<{
+    search: string;
+    range: BaseRange;
+  } | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const activeIndexRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadEmojis().then((list) => {
+      if (!cancelled) setEmojis(list);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtered = emojiState ? filterEmojis(emojis, emojiState.search) : [];
+  const isOpen = emojiState !== null && filtered.length > 0;
+
+  activeIndexRef.current = activeIndex;
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [emojiState?.search]);
+
+  const updateEmojiState = useCallback(() => {
+    try {
+      const result = getEmojiSearch(editor);
+      setEmojiState(result);
+    } catch {
+      setEmojiState(null);
+    }
+  }, [editor]);
+
+  useEffect(() => {
+    let editorEl: HTMLElement;
+    try {
+      editorEl = ReactEditor.toDOMNode(editor, editor);
+    } catch {
+      return;
+    }
+
+    const observer = new MutationObserver(updateEmojiState);
+    observer.observe(editorEl, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+    document.addEventListener('selectionchange', updateEmojiState);
+
+    return () => {
+      observer.disconnect();
+      document.removeEventListener('selectionchange', updateEmojiState);
+    };
+  }, [editor, updateEmojiState]);
+
+  const insertEmoji = useCallback(
+    (emoji: EmojiEntry) => {
+      if (!emojiState) return;
+      Transforms.select(editor, emojiState.range);
+      Transforms.insertText(editor, `:${emoji.id}: `);
+      setEmojiState(null);
+    },
+    [editor, emojiState],
+  );
+
+  const onKeyDown = useCallback(
+    (ev: React.KeyboardEvent): boolean => {
+      if (!isOpen) return false;
+
+      if (ev.key === 'ArrowUp') {
+        ev.preventDefault();
+        setActiveIndex((i) => (i <= 0 ? filtered.length - 1 : i - 1));
+        return true;
+      }
+      if (ev.key === 'ArrowDown') {
+        ev.preventDefault();
+        setActiveIndex((i) => (i >= filtered.length - 1 ? 0 : i + 1));
+        return true;
+      }
+      if (ev.key === 'Tab' || ev.key === 'Enter') {
+        ev.preventDefault();
+        const emoji = filtered[activeIndexRef.current];
+        if (emoji) insertEmoji(emoji);
+        return true;
+      }
+      if (ev.key === 'Escape') {
+        ev.preventDefault();
+        setEmojiState(null);
+        return true;
+      }
+      return false;
+    },
+    [isOpen, filtered, insertEmoji],
+  );
+
+  const overlay = isOpen ? (
+    <Overlay
+      onMouseDown={(e) => {
+        e.preventDefault();
+      }}
+    >
+      {filtered.map((emoji, i) => (
+        <EmojiItem
+          key={emoji.id}
+          active={i === activeIndex}
+          onClick={() => insertEmoji(emoji)}
+        >
+          <Native>{emoji.native}</Native>
+          <Name>{emoji.name}</Name>
+          <Shortcode>:{emoji.id}:</Shortcode>
+        </EmojiItem>
+      ))}
+    </Overlay>
+  ) : null;
+
+  return { overlay, onKeyDown };
+}

--- a/apps/client/src/components/surfaces/Messages/MessageEditor.tsx
+++ b/apps/client/src/components/surfaces/Messages/MessageEditor.tsx
@@ -18,6 +18,7 @@ import { Editable, ReactEditor, Slate, withReact } from 'slate-react';
 import { contextMenuState } from '@/components/ContextMenu';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
+import { useEmojiAutocomplete } from './EmojiAutocomplete';
 import { messageEditState } from './Message';
 import { useMentionAutocomplete } from './MentionAutocomplete';
 
@@ -262,6 +263,8 @@ export function MessageEditor({
 
   const { overlay: mentionOverlay, onKeyDown: mentionKeyDown } =
     useMentionAutocomplete({ editor, members });
+  const { overlay: emojiOverlay, onKeyDown: emojiKeyDown } =
+    useEmojiAutocomplete({ editor });
 
   const setContextMenu = useSetAtom(contextMenuState);
   const ref = useRef<HTMLDivElement>(null);
@@ -333,6 +336,7 @@ export function MessageEditor({
         )}
         <EditableContainer ref={ref}>
           {mentionOverlay}
+          {emojiOverlay}
           <Slate
             editor={editor}
             initialValue={editorValue}
@@ -342,6 +346,7 @@ export function MessageEditor({
               placeholder={placeholder}
               onKeyDown={(ev) => {
                 if (mentionKeyDown(ev)) return;
+                if (emojiKeyDown(ev)) return;
 
                 if (isMobile) {
                   onTyping?.();


### PR DESCRIPTION
## Summary
- Adds a `:shortcode` autocomplete popup to the message editor, mirroring the recently-added `@mention` autocomplete so users can pick emojis without opening the full picker.
- Inserts the shortcode form (`:id:`) on selection, consistent with `EmojiPicker` and the markdown renderer that converts shortcodes to emojis on display.

## Notes
- Triggers only when `:` is at a word boundary and followed by 2+ shortcode-valid chars, so punctuation and smileys like `:D` don't open the popup.
- Emoji data is dynamic-imported (same twitter set the picker uses) to keep it out of the initial bundle.

## Test plan
- [ ] Type `:smi` in the message editor and verify the popup shows matching emojis
- [ ] Tab/Enter inserts `:id: `; arrow keys navigate; Esc closes
- [ ] Typing `http://` or `12:30` does not open the popup
- [ ] Mention autocomplete (`@`) still works and takes precedence when both triggers are on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)