### PR TITLE
Show colored space initial in dockview tabs

### DIFF
--- a/apps/client/src/components/DockViewSurface.tsx
+++ b/apps/client/src/components/DockViewSurface.tsx
@@ -1,6 +1,7 @@
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { normalizeMediaUrl } from '@/components/atoms/Avatar';
+import { colorFromId } from '@/components/atoms/SpaceIcon';
 import {
   DockviewApi,
   DockviewDidDropEvent,
@@ -160,7 +161,7 @@ function CustomTabComponent(props: IDockviewPanelHeaderProps) {
           justifyContent: 'center',
         }}
       >
-        {tabName.icon && (
+        {(tabName.icon || tabName.spaceId) && (
           <span
             style={{
               marginRight: '6px',
@@ -169,12 +170,7 @@ function CustomTabComponent(props: IDockviewPanelHeaderProps) {
               flexShrink: 0,
             }}
           >
-            {isFontAwesomeIcon(tabName.icon) ? (
-              <FontAwesomeIcon
-                icon={tabName.icon}
-                style={{ fontSize: '12px' }}
-              />
-            ) : (
+            {tabName.icon && !isFontAwesomeIcon(tabName.icon) ? (
               <img
                 src={normalizeMediaUrl(tabName.icon as string)}
                 alt=""
@@ -185,7 +181,30 @@ function CustomTabComponent(props: IDockviewPanelHeaderProps) {
                   objectFit: 'cover',
                 }}
               />
-            )}
+            ) : tabName.spaceId ? (
+              <span
+                style={{
+                  width: '20px',
+                  height: '20px',
+                  borderRadius: '3px',
+                  backgroundColor: colorFromId(tabName.spaceId),
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: '11px',
+                  fontWeight: 700,
+                  color: 'white',
+                  fontFamily: 'var(--font-heading)',
+                }}
+              >
+                {tabName.spaceName?.[0] ?? ''}
+              </span>
+            ) : tabName.icon ? (
+              <FontAwesomeIcon
+                icon={tabName.icon as IconDefinition}
+                style={{ fontSize: '12px' }}
+              />
+            ) : null}
           </span>
         )}
         {title}

--- a/apps/client/src/components/atoms/SpaceIcon.tsx
+++ b/apps/client/src/components/atoms/SpaceIcon.tsx
@@ -18,7 +18,7 @@ function hashString(str: string): number {
   return Math.abs(hash);
 }
 
-function colorFromId(id: string): string {
+export function colorFromId(id: string): string {
   const hash = hashString(id);
   const hue = hash % 360;
   return `oklch(0.55 0.25 ${hue})`;

--- a/apps/client/src/components/surfaces/Documents/index.tsx
+++ b/apps/client/src/components/surfaces/Documents/index.tsx
@@ -304,7 +304,12 @@ export default function DocumentSurface({ channelId }: { channelId: string }) {
 
   return (
     <Surface scroll>
-      <TabName name={channel.name} icon={channel.space?.icon ?? faFileLines} />
+      <TabName
+        name={channel.name}
+        icon={channel.space?.icon ?? faFileLines}
+        spaceId={channel.space?.id}
+        spaceName={channel.space?.name}
+      />
       <DocumentActions>
         <Box className="left" fontWeight="semibold" color="gray.400">
           #{channel.name}

--- a/apps/client/src/components/surfaces/Messages/index.tsx
+++ b/apps/client/src/components/surfaces/Messages/index.tsx
@@ -264,7 +264,12 @@ function RealMessageView({ channel }: { channel: MikotoChannel }) {
 
   return (
     <Surface key={channel.id}>
-      <TabName name={displayName} icon={channel.space?.icon ?? faHashtag} />
+      <TabName
+        name={displayName}
+        icon={channel.space?.icon ?? faHashtag}
+        spaceId={channel.space?.id}
+        spaceName={channel.space?.name}
+      />
       <Grid templateRows="auto 24px" h="100%">
         <Flex direction="column">
           {msgs === null ? (

--- a/apps/client/src/components/surfaces/Voice.tsx
+++ b/apps/client/src/components/surfaces/Voice.tsx
@@ -64,7 +64,12 @@ export default function VoiceSurface({ channelId }: { channelId: string }) {
 
   return (
     <Surface data-lk-theme="default">
-      <TabName name={channel.name} icon={channel.space?.icon ?? faMicrophone} />
+      <TabName
+        name={channel.name}
+        icon={channel.space?.icon ?? faMicrophone}
+        spaceId={channel.space?.id}
+        spaceName={channel.space?.name}
+      />
       {voiceConfig && (
         <LiveKitRoom
           serverUrl={voiceConfig.url}

--- a/apps/client/src/components/tabs/index.tsx
+++ b/apps/client/src/components/tabs/index.tsx
@@ -4,7 +4,7 @@ import { useContext, useEffect } from 'react';
 
 import { TabContext, TabNameProps, tabNameFamily } from '@/store/surface';
 
-export function TabName({ name, icon }: TabNameProps) {
+export function TabName({ name, icon, spaceId, spaceName }: TabNameProps) {
   const tabInfo = useContext(TabContext);
   const [tabName, setTabName] = useAtom(tabNameFamily(tabInfo.key));
 
@@ -14,9 +14,11 @@ export function TabName({ name, icon }: TabNameProps) {
         ...tabName,
         name,
         icon,
+        spaceId,
+        spaceName,
       });
     }
-  }, [name, tabName, setTabName, tabInfo.key, icon]);
+  }, [name, tabName, setTabName, tabInfo.key, icon, spaceId, spaceName]);
 
   return <></>;
 }

--- a/apps/client/src/store/surface.ts
+++ b/apps/client/src/store/surface.ts
@@ -31,6 +31,8 @@ export const tabByIdSelector = atom((get) => (id: string) => {
 export interface TabNameProps {
   name: string;
   icon?: IconDefinition | string;
+  spaceId?: string;
+  spaceName?: string;
 }
 
 export const tabNameFamily = atomFamily((param: string) =>


### PR DESCRIPTION
## Summary
- When a space has no custom icon, dockview channel tabs now display a colored initial square (matching the space sidebar) instead of only a generic channel-type icon (hashtag, microphone, etc.)
- Reuses the existing `colorFromId` hashing logic from `SpaceIcon` for consistent colors across sidebar and tabs
- Non-space tabs (Friends, Search, etc.) continue to use their FontAwesome icons as before

## Test plan
- [ ] Open a channel in a space that has no custom icon — tab should show a colored initial square
- [ ] Open a channel in a space that has a custom icon — tab should show the space icon image
- [ ] Open non-space tabs (Friends, Search) — should still show FontAwesome icons
- [ ] Verify the tab initial color matches the sidebar color for the same space

🤖 Generated with [Claude Code](https://claude.com/claude-code)