### PR TITLE
Show last-edited time on document channels and fix floating toolbar

### DIFF
--- a/apps/client/src/components/surfaces/Documents/index.tsx
+++ b/apps/client/src/components/surfaces/Documents/index.tsx
@@ -30,12 +30,12 @@ import { MikotoChannel } from '@mikoto-io/mikoto.js';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { EditorState } from 'lexical';
 import { debounce } from 'lodash';
-import { PropsWithChildren, useCallback, useRef } from 'react';
+import { PropsWithChildren, useCallback, useRef, useState } from 'react';
 import { proxy, useSnapshot } from 'valtio';
 
 import { Surface } from '@/components/Surface';
 import { TabName } from '@/components/tabs';
-import { useMikoto } from '@/hooks';
+import { useInterval, useMikoto } from '@/hooks';
 import { createTooltip } from '@/ui';
 
 import { EDITOR_NODES } from './editorNodes';
@@ -46,6 +46,33 @@ import { HotkeyPlugin } from './plugins/HotkeyPlugin';
 import { ListBehaviorPlugin } from './plugins/ListBehaviorPlugin';
 import { MarkdownPastePlugin } from './plugins/MarkdownPastePlugin';
 import { lexicalTheme } from './theme';
+
+const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+function formatRelativeTime(date: Date): string {
+  const now = Date.now();
+  const diffMs = date.getTime() - now;
+  const diffSec = Math.round(diffMs / 1000);
+  const diffMin = Math.round(diffMs / 60000);
+  const diffHr = Math.round(diffMs / 3600000);
+  const diffDay = Math.round(diffMs / 86400000);
+
+  if (Math.abs(diffSec) < 60) return rtf.format(diffSec, 'second');
+  if (Math.abs(diffMin) < 60) return rtf.format(diffMin, 'minute');
+  if (Math.abs(diffHr) < 24) return rtf.format(diffHr, 'hour');
+  return rtf.format(diffDay, 'day');
+}
+
+function useRelativeTime(date: Date | undefined): string | undefined {
+  const [, setTick] = useState(0);
+
+  useInterval(() => {
+    setTick((t) => t + 1);
+  }, 10000);
+
+  if (!date) return undefined;
+  return formatRelativeTime(date);
+}
 
 // Zero-width space used as placeholder for empty lines
 const ZERO_WIDTH_SPACE = '\u200B';
@@ -301,6 +328,7 @@ export default function DocumentSurface({ channelId }: { channelId: string }) {
     }),
   ).current;
   const documentSnap = useSnapshot(documentState);
+  const lastEdited = useRelativeTime(channel.lastUpdatedDate);
 
   return (
     <Surface scroll>
@@ -311,9 +339,16 @@ export default function DocumentSurface({ channelId }: { channelId: string }) {
         spaceName={channel.space?.name}
       />
       <DocumentActions>
-        <Box className="left" fontWeight="semibold" color="gray.400">
-          #{channel.name}
-        </Box>
+        <Flex className="left" direction="column">
+          <Box fontWeight="semibold" color="gray.200">
+            {channel.name}
+          </Box>
+          {lastEdited && (
+            <Box fontSize="xs" color="gray.500">
+              edited {lastEdited}
+            </Box>
+          )}
+        </Flex>
         <Flex className="right" fontSize="xl" gap={3}>
           <Group>
             <ActionTooltip tooltip="Edit">

--- a/apps/client/src/components/surfaces/Documents/plugins/FloatingToolbarPlugin.tsx
+++ b/apps/client/src/components/surfaces/Documents/plugins/FloatingToolbarPlugin.tsx
@@ -44,7 +44,7 @@ const ToolbarContainer = styled.div`
   background: var(--chakra-colors-gray-800);
   border: 1px solid var(--chakra-colors-gray-600);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-  position: absolute;
+  position: fixed;
   z-index: 100;
   opacity: 0;
   pointer-events: none;
@@ -140,9 +140,8 @@ function FloatingToolbar({
       const toolbarWidth = toolbar.offsetWidth;
       const toolbarHeight = toolbar.offsetHeight;
 
-      const top = rect.top - toolbarHeight - 8 + window.scrollY;
-      const left =
-        rect.left + rect.width / 2 - toolbarWidth / 2 + window.scrollX;
+      const top = rect.top - toolbarHeight - 8;
+      const left = rect.left + rect.width / 2 - toolbarWidth / 2;
 
       toolbar.style.top = `${Math.max(0, top)}px`;
       toolbar.style.left = `${Math.max(0, left)}px`;

--- a/apps/superego/src/routes/channels/documents.rs
+++ b/apps/superego/src/routes/channels/documents.rs
@@ -25,6 +25,7 @@ use crate::{
     entities::{
         Channel, Document, DocumentPatch, MemberExt, MemberKey, Relationship, SpaceExt, SpaceUser,
     },
+    functions::time::Timestamp,
     error::Error,
     functions::jwt::{jwt_key, Claims},
     middlewares::load::Load,
@@ -58,6 +59,7 @@ async fn update(
     }
     let document = Document::get_by_channel_id(channel_id, db()).await?;
     let document = document.update(patch, db()).await?;
+    Channel::update_last_updated(channel_id, Timestamp::now(), db()).await?;
     Ok(document.into())
 }
 


### PR DESCRIPTION
## Summary
- Display relative "last edited" time (e.g. "edited 5 minutes ago") below the channel name in the document surface header, using the channel's existing `lastUpdated` field
- Update the backend document save handler to set the channel's `lastUpdated` timestamp when a document is modified
- Fix the floating toolbar using `position: fixed` so it positions correctly within the scrollable document surface

## Test plan
- [ ] Open a document channel and verify the "edited X ago" text appears below the channel name
- [ ] Edit and save a document, confirm the timestamp updates
- [ ] Select text in a document and verify the floating toolbar appears in the correct position

🤖 Generated with [Claude Code](https://claude.com/claude-code)