### PR TITLE
Remove unused yrs-axum collab WebSocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4572,7 +4572,6 @@ dependencies = [
  "url",
  "uuid",
  "yrs",
- "yrs-axum",
 ]
 
 [[package]]
@@ -5768,21 +5767,6 @@ dependencies = [
  "smallstr",
  "smallvec",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "yrs-axum"
-version = "0.1.0"
-source = "git+https://github.com/mikotoIO/yrs-axum?branch=master#d3f2401fb786cc5c87b4fdfcea456b1470fbdd83"
-dependencies = [
- "axum 0.7.9",
- "futures-util",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
- "tracing",
- "yrs",
 ]
 
 [[package]]

--- a/apps/superego/Cargo.toml
+++ b/apps/superego/Cargo.toml
@@ -125,7 +125,3 @@ features = ["tokio-rustls-tls"]
 version = "0.12.3"
 default-features = false
 features = ["charset", "http2", "rustls-tls"]
-
-[dependencies.yrs-axum]
-git = "https://github.com/mikotoIO/yrs-axum"
-branch = "master"

--- a/apps/superego/src/routes/channels/documents.rs
+++ b/apps/superego/src/routes/channels/documents.rs
@@ -1,33 +1,13 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, Weak},
-};
-
-use futures_util::StreamExt;
-use tokio::sync::{Mutex, RwLock};
-
 use aide::axum::routing::{get_with, patch_with};
-use axum::{
-    extract::{ws::WebSocket, Path, Query, WebSocketUpgrade},
-    response::Response,
-    Extension, Json, Router,
-};
+use axum::{extract::Path, Json};
 use uuid::Uuid;
-use yrs::{sync::Awareness, Doc};
-use yrs_axum::{
-    broadcast::BroadcastGroup,
-    ws::{AxumSink, AxumStream},
-    AwarenessRef,
-};
 
 use crate::{
     db::db,
-    entities::{
-        Channel, Document, DocumentPatch, MemberExt, MemberKey, Relationship, SpaceExt, SpaceUser,
-    },
-    functions::time::Timestamp,
+    entities::{Channel, Document, DocumentPatch, MemberExt, SpaceExt},
     error::Error,
-    functions::jwt::{jwt_key, Claims},
+    functions::jwt::Claims,
+    functions::time::Timestamp,
     middlewares::load::Load,
     routes::{router::AppRouter, ws::state::State},
 };
@@ -79,70 +59,4 @@ pub fn router() -> AppRouter<State> {
                 o.tag(TAG).id("documents.update").summary("Update Document")
             }),
         )
-}
-
-type BroadcastMap = Arc<Mutex<HashMap<String, Weak<BroadcastGroup>>>>;
-
-#[derive(Deserialize)]
-struct CollabParams {
-    token: Option<String>,
-}
-
-pub fn collab_ws() -> Router<()> {
-    let bcg_map: BroadcastMap = Arc::new(Mutex::new(HashMap::new()));
-
-    Router::<()>::new()
-        .route("/:room", axum::routing::get(ws_handler))
-        .layer(Extension(bcg_map))
-}
-
-async fn ws_handler(
-    Path(room): Path<String>,
-    Query(params): Query<CollabParams>,
-    ws: WebSocketUpgrade,
-    Extension(bcast): Extension<BroadcastMap>,
-) -> Result<Response, Error> {
-    // Authenticate the WebSocket connection
-    let token = params
-        .token
-        .ok_or(Error::unauthorized("Token not provided"))?;
-    let claims = Claims::decode(&token, jwt_key())?;
-    let user_id: Uuid = claims.sub.parse()?;
-
-    // The room format is the channel ID; verify the user is a member of the channel's space
-    let channel_id: Uuid = room.parse().map_err(|_| Error::NotFound)?;
-    let channel = Channel::find_by_id(channel_id, db()).await?;
-    if let Some(space_id) = channel.space_id {
-        SpaceUser::get_by_key(&MemberKey::new(space_id, user_id), db())
-            .await
-            .map_err(|_| Error::unauthorized("You are not a member of this space"))?;
-    } else {
-        // DM channel — verify user has a relationship with this channel
-        Relationship::find_by_channel(channel_id, user_id, db())
-            .await?
-            .ok_or(Error::unauthorized(
-                "You do not have access to this channel",
-            ))?;
-    }
-
-    Ok(ws.on_upgrade(move |socket| peer(room, socket, bcast)))
-}
-
-async fn peer(room: String, ws: WebSocket, bcg_map: BroadcastMap) {
-    let mut bcg_map = bcg_map.lock().await;
-    let bcast = match bcg_map.get(&room).and_then(|bc| bc.upgrade()) {
-        Some(bcast) => bcast,
-        None => {
-            let awareness: AwarenessRef = Arc::new(RwLock::new(Awareness::new(Doc::new())));
-            let bcast = Arc::new(BroadcastGroup::new(awareness.clone(), 32).await);
-            bcg_map.insert(room, Arc::downgrade(&bcast));
-            bcast
-        }
-    };
-
-    let (sink, stream) = ws.split();
-    let sink = Arc::new(Mutex::new(AxumSink::from(sink)));
-    let stream = AxumStream::from(stream);
-    let sub = bcast.subscribe(sink, stream);
-    if (sub.completed().await).is_ok() {}
 }

--- a/apps/superego/src/routes/mod.rs
+++ b/apps/superego/src/routes/mod.rs
@@ -5,7 +5,7 @@ use aide::{
     openapi::{Info, OpenApi},
 };
 use axum::{extract::Request, middleware, Extension, Json, Router};
-use channels::{documents::collab_ws, voice};
+use channels::voice;
 use http::header::{AUTHORIZATION, CONTENT_TYPE};
 use router::AppRouter;
 use schemars::JsonSchema;
@@ -206,7 +206,6 @@ pub fn router() -> Router {
             },
             ..OpenApi::default()
         })
-        .nest("/collab", collab_ws())
         .layer(middleware::from_fn(security_headers))
         .layer({
             let cors = CorsLayer::new()


### PR DESCRIPTION
## Summary
- Drop the `/collab` WebSocket handler in superego along with its `yrs-axum` git dependency; the endpoint was dead code.
- Clean up now-unused imports in `routes/channels/documents.rs` and the route mount in `routes/mod.rs`.

## Test plan
- [x] `cargo check` on superego passes
- [x] `moon :typecheck` across the repo