### PR TITLE
Prevent flash when toggling document read/edit mode

### DIFF
--- a/apps/client/src/components/surfaces/Documents/index.tsx
+++ b/apps/client/src/components/surfaces/Documents/index.tsx
@@ -162,6 +162,10 @@ const ActionTooltip = createTooltip({
 function DocumentActions({ children }: PropsWithChildren) {
   return (
     <Flex
+      position="sticky"
+      top={0}
+      zIndex={1}
+      bg="surface"
       borderBottom="1px solid"
       borderBottomColor="gray.650"
       px={4}
@@ -480,7 +484,7 @@ export default function DocumentSurface({ channelId }: { channelId: string }) {
           </Group>
         </Flex>
       </DocumentActions>
-      <Box px={8}>
+      <Box px={8} pb={32}>
         {documentSnap.type === 'read' && <DocumentReader channel={channel} />}
         {documentSnap.type === 'edit' && (
           <DocumentEditor channel={channel} documentState={documentState} />

--- a/apps/client/src/components/surfaces/Documents/index.tsx
+++ b/apps/client/src/components/surfaces/Documents/index.tsx
@@ -217,18 +217,16 @@ function documentContentQuery(channel: MikotoChannel) {
   };
 }
 
-function DocumentReader({ channel }: { channel: MikotoChannel }) {
-  const { data: document } = useSuspenseQuery(documentContentQuery(channel));
-
+function DocumentReadOnly({ content }: { content: string }) {
   return (
     <LexicalComposer
-      key={hash(document.content)}
+      key={hash(content)}
       initialConfig={{
         namespace: 'Editor',
         editable: false,
         nodes: EDITOR_NODES,
         theme: lexicalTheme,
-        editorState: () => markdownToEditor(document.content),
+        editorState: () => markdownToEditor(content),
         onError(error: Error) {
           throw error;
         },
@@ -241,6 +239,11 @@ function DocumentReader({ channel }: { channel: MikotoChannel }) {
       />
     </LexicalComposer>
   );
+}
+
+function DocumentReader({ channel }: { channel: MikotoChannel }) {
+  const { data: document } = useSuspenseQuery(documentContentQuery(channel));
+  return <DocumentReadOnly content={document.content} />;
 }
 
 function DocumentEditor({
@@ -262,29 +265,43 @@ function DocumentEditor({
     staleTime: Infinity,
     gcTime: Infinity,
   });
+  // The collab provider needs a round-trip to sync before the editor shows
+  // any content, which would otherwise flash empty. Keep a read-only view
+  // overlaid on top until the provider fires its first sync event.
+  const [synced, setSynced] = useState(false);
 
   return (
-    <LexicalCollaboration>
-      <LexicalComposer
-        initialConfig={{
-          namespace: 'Editor',
-          editable: true,
-          nodes: EDITOR_NODES,
-          theme: lexicalTheme,
-          editorState: null,
-          onError(error: Error) {
-            throw error;
-          },
-        }}
-      >
-        <DocumentEditorInner
-          channel={channel}
-          documentState={documentState}
-          initialContent={document.content}
-          shouldBootstrap={shouldBootstrap}
-        />
-      </LexicalComposer>
-    </LexicalCollaboration>
+    <Box position="relative">
+      <Box visibility={synced ? 'visible' : 'hidden'}>
+        <LexicalCollaboration>
+          <LexicalComposer
+            initialConfig={{
+              namespace: 'Editor',
+              editable: true,
+              nodes: EDITOR_NODES,
+              theme: lexicalTheme,
+              editorState: null,
+              onError(error: Error) {
+                throw error;
+              },
+            }}
+          >
+            <DocumentEditorInner
+              channel={channel}
+              documentState={documentState}
+              initialContent={document.content}
+              shouldBootstrap={shouldBootstrap}
+              onSync={() => setSynced(true)}
+            />
+          </LexicalComposer>
+        </LexicalCollaboration>
+      </Box>
+      {!synced && (
+        <Box position="absolute" top={0} left={0} right={0}>
+          <DocumentReadOnly content={document.content} />
+        </Box>
+      )}
+    </Box>
   );
 }
 
@@ -309,14 +326,16 @@ function DocumentEditorInner({
   documentState,
   initialContent,
   shouldBootstrap,
+  onSync,
 }: {
   channel: MikotoChannel;
   documentState: DocumentState;
   initialContent: string;
   shouldBootstrap: boolean;
+  onSync?: () => void;
 }) {
   const mikoto = useMikoto();
-  const { providerFactory } = useProviderFactory({ channel });
+  const { providerFactory } = useProviderFactory({ channel, onSync });
   const me = mikoto.user.me;
   const username = me?.name ?? 'Anonymous';
   const cursorColor = me ? cursorColorFor(me.id) : CURSOR_COLORS[0];

--- a/apps/client/src/components/surfaces/Documents/index.tsx
+++ b/apps/client/src/components/surfaces/Documents/index.tsx
@@ -28,7 +28,7 @@ import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPl
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { MikotoChannel } from '@mikoto-io/mikoto.js';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { debounce } from 'lodash';
 import { PropsWithChildren, useCallback, useRef, useState } from 'react';
 import { proxy, useSnapshot } from 'valtio';
@@ -210,13 +210,15 @@ function hash(str: string) {
   return hash;
 }
 
-function DocumentReader({ channel }: { channel: MikotoChannel }) {
-  const { data: document } = useSuspenseQuery({
+function documentContentQuery(channel: MikotoChannel) {
+  return {
     queryKey: ['documents.get', channel.spaceId, channel.id],
-    queryFn: async () => {
-      return channel.getDocument();
-    },
-  });
+    queryFn: async () => channel.getDocument(),
+  };
+}
+
+function DocumentReader({ channel }: { channel: MikotoChannel }) {
+  const { data: document } = useSuspenseQuery(documentContentQuery(channel));
 
   return (
     <LexicalComposer
@@ -248,18 +250,17 @@ function DocumentEditor({
   channel: MikotoChannel;
   documentState: DocumentState;
 }) {
-  const { data } = useSuspenseQuery({
-    queryKey: ['documents.editor-init', channel.spaceId, channel.id],
-    queryFn: async () => {
-      // Fetch the document and claim bootstrap rights in parallel. Only one
-      // client per session gets shouldBootstrap=true, which prevents the
-      // duplicate-content race when multiple peers open a cold room together.
-      const [document, shouldBootstrap] = await Promise.all([
-        channel.getDocument(),
-        channel.claimDocumentBootstrap(),
-      ]);
-      return { document, shouldBootstrap };
-    },
+  // Reuse the reader's cached content so toggling into edit mode doesn't
+  // re-fetch and fall through Suspense (which flashes the surface loader).
+  const { data: document } = useSuspenseQuery(documentContentQuery(channel));
+  // Only one client per session gets shouldBootstrap=true — the server
+  // enforces single-claim semantics, and we cache the result forever so
+  // repeated read/edit toggles don't trigger a Suspense fallback.
+  const { data: shouldBootstrap } = useSuspenseQuery({
+    queryKey: ['documents.bootstrap-claim', channel.spaceId, channel.id],
+    queryFn: async () => channel.claimDocumentBootstrap(),
+    staleTime: Infinity,
+    gcTime: Infinity,
   });
 
   return (
@@ -279,8 +280,8 @@ function DocumentEditor({
         <DocumentEditorInner
           channel={channel}
           documentState={documentState}
-          initialContent={data.document.content}
-          shouldBootstrap={data.shouldBootstrap}
+          initialContent={document.content}
+          shouldBootstrap={shouldBootstrap}
         />
       </LexicalComposer>
     </LexicalCollaboration>
@@ -367,6 +368,7 @@ function DocumentAutosave({
   documentState: DocumentState;
 }) {
   const [editor] = useLexicalComposerContext();
+  const queryClient = useQueryClient();
 
   const save = useCallback(
     debounce(() => {
@@ -376,14 +378,21 @@ function DocumentAutosave({
         .read(() => editorToMarkdown());
       channel
         .updateDocument({ content })
-        .then(() => {
+        .then((updated) => {
           documentState.save = 'synced';
+          // Keep the reader's cache in sync with what we just persisted, so
+          // switching back to read mode doesn't trigger a background refetch
+          // that re-keys the LexicalComposer and flashes the surface.
+          queryClient.setQueryData(
+            ['documents.get', channel.spaceId, channel.id],
+            updated,
+          );
         })
         .catch(() => {
           documentState.save = 'error';
         });
     }, 1500),
-    [channel, documentState, editor],
+    [channel, documentState, editor, queryClient],
   );
 
   return <OnChangePlugin ignoreSelectionChange onChange={save} />;


### PR DESCRIPTION
## Summary

Toggling a document channel between read and edit mode flashed the surface loader. Three causes, each fixed:

- The editor used a different query key (`documents.editor-init`) than the reader (`documents.get`), so entering edit mode always re-fetched and fell through Suspense into the surface loading state. The two now share one query via a small `documentContentQuery` helper and read from cache on the toggle.
- The bootstrap claim was bundled into the editor-init fetch. It's now its own `useSuspenseQuery` with `staleTime: Infinity` / `gcTime: Infinity` — only the first edit entry pays the round-trip; subsequent toggles are instant.
- Autosave didn't update the reader's React Query cache, so returning to read mode could trigger a stale refetch whose new content re-keyed `LexicalComposer` (the `key={hash(document.content)}` remount). The autosave success handler now writes the saved document back into the reader cache via `queryClient.setQueryData`.

## Test plan

- [ ] Open a document channel and repeatedly toggle pencil ↔ save. No flash of the loading surface, no blank editor, no remount jump.
- [ ] Edit a document, wait for autosave, then switch to read mode — content matches what was just typed with no refetch flicker.
- [ ] Open the same document in two clients, confirm collaboration still bootstraps correctly (only one client claims).

🤖 Generated with [Claude Code](https://claude.com/claude-code)