### PR TITLE
Derive collab WebSocket URL from PUBLIC_SERVER_URL

### DIFF
--- a/apps/client/src/components/surfaces/Documents/providerFactory.tsx
+++ b/apps/client/src/components/surfaces/Documents/providerFactory.tsx
@@ -56,7 +56,7 @@ export function useProviderFactory({
       if (!providerRef.current) {
         const doc = new Y.Doc();
         const provider = new WebsocketProvider(
-          env.PUBLIC_COLLABORATION_URL,
+          `${env.PUBLIC_SERVER_URL.replace(/^http/, 'ws')}/collab`,
           id,
           doc,
           {

--- a/apps/client/src/env.ts
+++ b/apps/client/src/env.ts
@@ -6,8 +6,6 @@ export const env = {
     import.meta.env.PUBLIC_SERVER_URL ?? 'http://localhost:3511',
   PUBLIC_MEDIASERVER_URL:
     import.meta.env.PUBLIC_MEDIASERVER_URL ?? 'http://localhost:9501',
-  PUBLIC_COLLABORATION_URL:
-    import.meta.env.PUBLIC_COLLABORATION_URL ?? 'ws://localhost:3511/collab',
   PUBLIC_CAPTCHA_KEY:
     import.meta.env.PUBLIC_CAPTCHA_KEY ?? '1x00000000000000000000AA',
 };


### PR DESCRIPTION
## Summary
- Remove the `PUBLIC_COLLABORATION_URL` env var from the client and derive the collab WebSocket endpoint from `PUBLIC_SERVER_URL` instead (swap `http`→`ws` / `https`→`wss`, append `/collab`).

Collab is mounted on the superego API server at `/collab`, so the separate env var was redundant — and easy to forget when changing `PUBLIC_SERVER_URL` in a deployment, silently breaking doc sync.

## Test plan
- [ ] `moon :typecheck` passes
- [ ] Open a document; verify the collab WebSocket connects and edits sync