### PR TITLE
feat(documents): slash menu and check lists

### DIFF
--- a/apps/client/src/components/surfaces/Documents/index.tsx
+++ b/apps/client/src/components/surfaces/Documents/index.tsx
@@ -17,6 +17,7 @@ import {
   AutoLinkPlugin,
   createLinkMatcherWithRegExp,
 } from '@lexical/react/LexicalAutoLinkPlugin';
+import { CheckListPlugin } from '@lexical/react/LexicalCheckListPlugin';
 import { LexicalCollaboration } from '@lexical/react/LexicalCollaborationContext';
 import { CollaborationPlugin } from '@lexical/react/LexicalCollaborationPlugin';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
@@ -45,6 +46,7 @@ import { HotkeyPlugin } from './plugins/HotkeyPlugin';
 import { ImageUploadPlugin } from './plugins/ImageUploadPlugin';
 import { ListBehaviorPlugin } from './plugins/ListBehaviorPlugin';
 import { MarkdownPastePlugin } from './plugins/MarkdownPastePlugin';
+import { SlashMenuPlugin } from './plugins/SlashMenuPlugin';
 import { useProviderFactory } from './providerFactory';
 import { lexicalTheme } from './theme';
 import { DOCUMENT_TRANSFORMERS } from './transformers';
@@ -115,6 +117,56 @@ const EditorWrapper = styled.div`
 
   .editor-listitem {
     margin: 8px 0;
+  }
+
+  .editor-list-check {
+    list-style-type: none;
+    padding-left: 0;
+  }
+
+  .editor-listitem-checked,
+  .editor-listitem-unchecked {
+    position: relative;
+    list-style-type: none;
+    padding-left: 26px;
+    outline: none;
+    margin: 4px 0;
+  }
+
+  .editor-listitem-checked::before,
+  .editor-listitem-unchecked::before {
+    content: '';
+    position: absolute;
+    left: 2px;
+    top: 4px;
+    width: 16px;
+    height: 16px;
+    border: 1.5px solid var(--chakra-colors-gray-500);
+    border-radius: 3px;
+    background-color: transparent;
+    cursor: pointer;
+    box-sizing: border-box;
+    transition:
+      background-color 0.12s ease,
+      border-color 0.12s ease;
+  }
+
+  .editor-listitem-unchecked:hover::before {
+    border-color: var(--chakra-colors-gray-300);
+  }
+
+  .editor-listitem-checked::before {
+    background-color: var(--chakra-colors-blue-500);
+    border-color: var(--chakra-colors-blue-500);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='white' d='M13.485 1.929a1 1 0 0 1 1.414 1.414l-8.486 8.486a1 1 0 0 1-1.414 0L1.464 8.314a1 1 0 1 1 1.414-1.414l3.235 3.235 7.372-7.372z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 12px 12px;
+  }
+
+  .editor-listitem-checked {
+    text-decoration: line-through;
+    color: var(--chakra-colors-gray-500);
   }
 
   .editor-input {
@@ -433,7 +485,9 @@ function DocumentEditorInner({
       <AutoLinkPlugin matchers={LINK_MATCHERS} />
       <HotkeyPlugin channel={channel} />
       <ListBehaviorPlugin />
+      <CheckListPlugin />
       <CodeBlockPlugin />
+      <SlashMenuPlugin />
       <FloatingToolbarPlugin />
       {anchorElem && <DraggableBlockPlugin anchorElem={anchorElem} />}
       <CollaborationPlugin

--- a/apps/client/src/components/surfaces/Documents/plugins/SlashMenuPlugin.tsx
+++ b/apps/client/src/components/surfaces/Documents/plugins/SlashMenuPlugin.tsx
@@ -1,0 +1,285 @@
+import styled from '@emotion/styled';
+import {
+  faCode,
+  faFont,
+  faHeading,
+  faImage,
+  faListCheck,
+  faListOl,
+  faListUl,
+  faMinus,
+  faQuoteRight,
+  IconDefinition,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { $createCodeNode } from '@lexical/code';
+import {
+  INSERT_CHECK_LIST_COMMAND,
+  INSERT_ORDERED_LIST_COMMAND,
+  INSERT_UNORDERED_LIST_COMMAND,
+} from '@lexical/list';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { INSERT_HORIZONTAL_RULE_COMMAND } from '@lexical/react/LexicalHorizontalRuleNode';
+import {
+  LexicalTypeaheadMenuPlugin,
+  MenuOption,
+  useBasicTypeaheadTriggerMatch,
+} from '@lexical/react/LexicalTypeaheadMenuPlugin';
+import {
+  $createHeadingNode,
+  $createQuoteNode,
+  HeadingTagType,
+} from '@lexical/rich-text';
+import { $setBlocksType } from '@lexical/selection';
+import {
+  $createParagraphNode,
+  $getSelection,
+  $insertNodes,
+  $isRangeSelection,
+  ElementNode,
+  LexicalEditor,
+  TextNode,
+} from 'lexical';
+import { useCallback, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { uploadFile } from '@/functions/fileUpload';
+
+import { $createImageNode } from '../nodes/ImageNode';
+
+class SlashMenuOption extends MenuOption {
+  readonly label: string;
+  readonly iconDef: IconDefinition;
+  readonly keywords: string[];
+  readonly onSelect: (editor: LexicalEditor) => void;
+
+  constructor(
+    label: string,
+    options: {
+      icon: IconDefinition;
+      keywords?: string[];
+      onSelect: (editor: LexicalEditor) => void;
+    },
+  ) {
+    super(label);
+    this.label = label;
+    this.iconDef = options.icon;
+    this.keywords = options.keywords ?? [];
+    this.onSelect = options.onSelect;
+  }
+}
+
+function $setBlockType(creator: () => ElementNode) {
+  const selection = $getSelection();
+  if ($isRangeSelection(selection)) {
+    $setBlocksType(selection, creator);
+  }
+}
+
+function $setHeading(level: HeadingTagType) {
+  $setBlockType(() => $createHeadingNode(level));
+}
+
+function getBaseOptions(editor: LexicalEditor): SlashMenuOption[] {
+  return [
+    new SlashMenuOption('Text', {
+      icon: faFont,
+      keywords: ['paragraph', 'text', 'plain'],
+      onSelect: () => $setBlockType(() => $createParagraphNode()),
+    }),
+    new SlashMenuOption('Heading 1', {
+      icon: faHeading,
+      keywords: ['heading', 'header', 'h1', 'title'],
+      onSelect: () => $setHeading('h1'),
+    }),
+    new SlashMenuOption('Heading 2', {
+      icon: faHeading,
+      keywords: ['heading', 'header', 'h2', 'subtitle'],
+      onSelect: () => $setHeading('h2'),
+    }),
+    new SlashMenuOption('Heading 3', {
+      icon: faHeading,
+      keywords: ['heading', 'header', 'h3'],
+      onSelect: () => $setHeading('h3'),
+    }),
+    new SlashMenuOption('Bulleted List', {
+      icon: faListUl,
+      keywords: ['bullet', 'unordered', 'ul', 'list'],
+      onSelect: () =>
+        editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined),
+    }),
+    new SlashMenuOption('Numbered List', {
+      icon: faListOl,
+      keywords: ['number', 'ordered', 'ol', 'list'],
+      onSelect: () =>
+        editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined),
+    }),
+    new SlashMenuOption('Check List', {
+      icon: faListCheck,
+      keywords: ['check', 'checklist', 'todo', 'task', 'list'],
+      onSelect: () =>
+        editor.dispatchCommand(INSERT_CHECK_LIST_COMMAND, undefined),
+    }),
+    new SlashMenuOption('Quote', {
+      icon: faQuoteRight,
+      keywords: ['quote', 'blockquote'],
+      onSelect: () => $setBlockType(() => $createQuoteNode()),
+    }),
+    new SlashMenuOption('Code Block', {
+      icon: faCode,
+      keywords: ['code', 'codeblock', 'pre', 'snippet'],
+      onSelect: () => $setBlockType(() => $createCodeNode()),
+    }),
+    new SlashMenuOption('Divider', {
+      icon: faMinus,
+      keywords: ['divider', 'hr', 'horizontal', 'rule', 'separator'],
+      onSelect: () =>
+        editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND, undefined),
+    }),
+    new SlashMenuOption('Image', {
+      icon: faImage,
+      keywords: ['image', 'picture', 'photo', 'media'],
+      onSelect: () => {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = 'image/*';
+        input.onchange = async () => {
+          const file = input.files?.[0];
+          if (!file) return;
+          const response = await uploadFile('/attachment', file);
+          editor.update(() => {
+            const selection = $getSelection();
+            if (!$isRangeSelection(selection)) return;
+            $insertNodes([$createImageNode(response.data.url, file.name)]);
+          });
+        };
+        input.click();
+      },
+    }),
+  ];
+}
+
+const MenuContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 240px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 4px;
+  background: var(--chakra-colors-gray-800);
+  border: 1px solid var(--chakra-colors-gray-600);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+`;
+
+const MenuItem = styled.button<{ selected?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  background: ${(p) =>
+    p.selected ? 'var(--chakra-colors-gray-700)' : 'transparent'};
+  color: var(--chakra-colors-gray-100);
+  border-radius: 4px;
+  cursor: pointer;
+  text-align: left;
+  font-size: 13px;
+
+  &:hover {
+    background: var(--chakra-colors-gray-700);
+  }
+`;
+
+const MenuItemIcon = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--chakra-colors-gray-300);
+  font-size: 12px;
+`;
+
+const EmptyMessage = styled.div`
+  padding: 8px;
+  color: var(--chakra-colors-gray-400);
+  font-size: 12px;
+`;
+
+export function SlashMenuPlugin() {
+  const [editor] = useLexicalComposerContext();
+  const [query, setQuery] = useState<string | null>(null);
+
+  const baseOptions = useMemo(() => getBaseOptions(editor), [editor]);
+
+  const options = useMemo(() => {
+    if (!query) return baseOptions;
+    const q = query.toLowerCase();
+    return baseOptions.filter((opt) => {
+      if (opt.label.toLowerCase().includes(q)) return true;
+      return opt.keywords.some((k) => k.includes(q));
+    });
+  }, [baseOptions, query]);
+
+  const triggerFn = useBasicTypeaheadTriggerMatch('/', { minLength: 0 });
+
+  const onSelectOption = useCallback(
+    (
+      selectedOption: SlashMenuOption,
+      nodeToRemove: TextNode | null,
+      closeMenu: () => void,
+    ) => {
+      editor.update(() => {
+        nodeToRemove?.remove();
+        selectedOption.onSelect(editor);
+      });
+      closeMenu();
+    },
+    [editor],
+  );
+
+  return (
+    <LexicalTypeaheadMenuPlugin<SlashMenuOption>
+      triggerFn={triggerFn}
+      onQueryChange={setQuery}
+      onSelectOption={onSelectOption}
+      options={options}
+      menuRenderFn={(
+        anchorElementRef,
+        { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex },
+      ) => {
+        if (!anchorElementRef.current) return null;
+        return createPortal(
+          <MenuContainer>
+            {options.length === 0 ? (
+              <EmptyMessage>No matching blocks</EmptyMessage>
+            ) : (
+              options.map((option, i) => (
+                <MenuItem
+                  key={option.key}
+                  ref={(el) => option.setRefElement(el)}
+                  selected={selectedIndex === i}
+                  onMouseEnter={() => setHighlightedIndex(i)}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    setHighlightedIndex(i);
+                    selectOptionAndCleanUp(option);
+                  }}
+                >
+                  <MenuItemIcon>
+                    <FontAwesomeIcon icon={option.iconDef} />
+                  </MenuItemIcon>
+                  {option.label}
+                </MenuItem>
+              ))
+            )}
+          </MenuContainer>,
+          anchorElementRef.current,
+        );
+      }}
+    />
+  );
+}

--- a/apps/client/src/components/surfaces/Documents/theme.tsx
+++ b/apps/client/src/components/surfaces/Documents/theme.tsx
@@ -10,7 +10,10 @@ export const lexicalTheme = {
   image: 'editor-image',
   link: 'editor-link',
   list: {
+    checklist: 'editor-list-check',
     listitem: 'editor-listitem',
+    listitemChecked: 'editor-listitem-checked',
+    listitemUnchecked: 'editor-listitem-unchecked',
     nested: {
       listitem: 'editor-nested-listitem',
     },

--- a/apps/client/src/components/surfaces/Documents/transformers.ts
+++ b/apps/client/src/components/surfaces/Documents/transformers.ts
@@ -1,4 +1,8 @@
-import { TextMatchTransformer, TRANSFORMERS } from '@lexical/markdown';
+import {
+  CHECK_LIST,
+  TextMatchTransformer,
+  TRANSFORMERS,
+} from '@lexical/markdown';
 
 import {
   $createImageNode,
@@ -38,4 +42,8 @@ export const IMAGE: TextMatchTransformer = {
 // swaps to a wider one if `endIndex > existingEnd`. `![alt](url)` and
 // `[alt](url)` end at the same index, so a later-iterated IMAGE cannot
 // displace a first-matched LINK — we have to iterate IMAGE first.
-export const DOCUMENT_TRANSFORMERS = [IMAGE, ...TRANSFORMERS];
+//
+// CHECK_LIST must come before the default TRANSFORMERS because UNORDERED_LIST's
+// regex `^(\s*)[-*+]\s/` would otherwise swallow the `- ` prefix of a `- [x]`
+// line before the stricter check-list regex got a chance to match.
+export const DOCUMENT_TRANSFORMERS = [IMAGE, CHECK_LIST, ...TRANSFORMERS];


### PR DESCRIPTION
## Summary
- Adds a `/`-triggered typeahead menu to the document editor for inserting blocks (text, headings, bulleted/numbered/check lists, quote, code, divider, image), giving users a discoverable way to reach block types without memorising markdown shortcuts.
- Wires up Lexical's `CheckListPlugin` with custom checkbox styling (uses Chakra tokens so it follows the theme) and theme classes for checked/unchecked list items.
- Registers `CHECK_LIST` ahead of the default markdown transformers so `- [x]` parses as a check item — the default `UNORDERED_LIST` regex would otherwise swallow the `- ` prefix first.

## Test plan
- [ ] Open a document and type `/` — menu appears; filtering by keyword works; selecting each option inserts the expected block.
- [ ] `/image` picks a file, uploads, and inserts the image inline.
- [ ] Create a check list via slash menu and via `- [ ]` markdown paste; toggling checkboxes persists through reload.
- [ ] Verify nested and mixed list behaviour still works (bulleted/numbered lists unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)