### PR TITLE
Fix crash when opening DM channels

### DIFF
--- a/apps/client/src/components/surfaces/Messages/index.tsx
+++ b/apps/client/src/components/surfaces/Messages/index.tsx
@@ -11,13 +11,12 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import throttle from 'lodash/throttle';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
-import { useSnapshot } from 'valtio';
 
 import { Surface } from '@/components/Surface';
 import { TabName } from '@/components/tabs';
 import { Skeleton, SkeletonCircle } from '@/components/ui/skeleton';
 import { uploadFile } from '@/functions/fileUpload';
-import { useFetchMember, useMikoto } from '@/hooks';
+import { useFetchMember, useMaybeSnapshot, useMikoto } from '@/hooks';
 import { CurrentSpaceContext } from '@/store';
 
 import { DateSeparator, showDateSeparator } from './DateSeparator';
@@ -112,7 +111,7 @@ function RealMessageView({ channel }: { channel: MikotoChannel }) {
 
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const mikoto = useMikoto();
-  const membersCache = useSnapshot(channel.space?.members.cache ?? new Map());
+  const membersCache = useMaybeSnapshot(channel.space?.members.cache ?? new Map());
   const spaceMembers = useMemo(
     () => Array.from(membersCache.values()),
     [membersCache],


### PR DESCRIPTION
## Summary

- Fixes "can't access property Symbol.iterator, t is undefined" error when clicking on a DM conversation
- Root cause: valtio v2's `useSnapshot` crashes when passed a non-proxy object. DM channels have no space, so `channel.space?.members.cache ?? new Map()` fell back to a plain `Map`, which valtio tried to destructure internally
- Replaced `useSnapshot` with the existing `useMaybeSnapshot` helper, which safely handles non-proxy objects

## Test plan

- [ ] Open a DM conversation — should load without crashing
- [ ] Verify space channel messages still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)