### PR TITLE
Add DM message previews and unread indicators to sidebar

### DIFF
--- a/apps/client/src/components/sidebars/FriendSidebar.tsx
+++ b/apps/client/src/components/sidebars/FriendSidebar.tsx
@@ -2,17 +2,25 @@ import { Box, Heading } from '@chakra-ui/react';
 import styled from '@emotion/styled';
 import {
   faEarthAmericas,
+  faImage,
   faUserGroup,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useEffect } from 'react';
 import { useSnapshot } from 'valtio/react';
 
 import { Avatar } from '@/components/atoms/Avatar';
 import { hoverableButtonLike } from '@/components/design';
 import { useMikoto } from '@/hooks';
+import {
+  type DmPreview,
+  dmPreviewStore,
+  loadDmPreviews,
+} from '@/store/dmPreviews';
 import { useTabkit } from '@/store/surface';
+import { ackChannel, ackStore, isChannelUnread } from '@/store/unreads';
 
-const StyledButtonBase = styled.div`
+const SimpleButton = styled.div`
   display: flex;
   height: 40px;
   width: 100%;
@@ -27,18 +35,158 @@ const StyledButtonBase = styled.div`
   }
 `;
 
+const DmItem = styled.div<{ unread: boolean }>`
+  display: flex;
+  height: 52px;
+  width: 100%;
+  padding: 6px 8px;
+  gap: 10px;
+  align-items: center;
+  color: ${({ unread }) =>
+    unread ? 'var(--chakra-colors-text)' : 'var(--chakra-colors-gray-300)'};
+  font-weight: ${({ unread }) => (unread ? 600 : 400)};
+
+  ${hoverableButtonLike}
+`;
+
+const DmMeta = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+`;
+
+const DmTopRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+`;
+
+const DmName = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+`;
+
+const DmTimestamp = styled.span<{ unread: boolean }>`
+  font-size: 11px;
+  color: ${({ unread }) =>
+    unread
+      ? 'var(--chakra-colors-primary-400)'
+      : 'var(--chakra-colors-gray-400)'};
+  flex-shrink: 0;
+`;
+
+const DmPreviewRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--chakra-colors-gray-400);
+  min-width: 0;
+`;
+
+const DmPreviewText = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+`;
+
+const UnreadDot = styled.div`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--chakra-colors-primary-400);
+  flex-shrink: 0;
+`;
+
+function formatRelativeTime(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const then = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - then.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return 'now';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h`;
+  const sameYear = then.getFullYear() === now.getFullYear();
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d`;
+  if (sameYear) {
+    return then.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+  return then.toLocaleDateString(undefined, {
+    year: '2-digit',
+    month: 'short',
+  });
+}
+
+function previewText(
+  preview: DmPreview | undefined,
+  selfId: string | undefined,
+): string {
+  if (!preview) return 'No messages yet';
+  const isSelf = selfId && preview.authorId === selfId;
+  const prefix = isSelf ? 'You: ' : '';
+  if (!preview.content) {
+    if (preview.hasAttachments) return `${prefix}Sent an attachment`;
+    return `${prefix}…`;
+  }
+  return `${prefix}${preview.content}`;
+}
+
 export function FriendSidebar() {
   const tabkit = useTabkit();
   const mikoto = useMikoto();
 
   useSnapshot(mikoto.relationships.cache);
+  useSnapshot(mikoto.channels.cache);
+  useSnapshot(ackStore);
+  const previewsSnap = useSnapshot(dmPreviewStore);
 
   const friends = mikoto.relationships.friends;
   const dmFriends = friends.filter((f) => f.channelId);
 
+  const sortedDmFriends = [...dmFriends].sort((a, b) => {
+    const aChannel = a.channelId
+      ? mikoto.channels._get(a.channelId)
+      : undefined;
+    const bChannel = b.channelId
+      ? mikoto.channels._get(b.channelId)
+      : undefined;
+    const aTime = aChannel?.lastUpdated
+      ? new Date(aChannel.lastUpdated).getTime()
+      : 0;
+    const bTime = bChannel?.lastUpdated
+      ? new Date(bChannel.lastUpdated).getTime()
+      : 0;
+    return bTime - aTime;
+  });
+
+  useEffect(() => {
+    const channelIds = dmFriends
+      .map((f) => f.channelId)
+      .filter((id): id is string => Boolean(id));
+    if (channelIds.length > 0) {
+      loadDmPreviews(mikoto, channelIds);
+    }
+  }, [mikoto, dmFriends.map((f) => f.channelId).join(',')]);
+
+  const selfId = mikoto.user.me?.id;
+
   return (
     <Box p={2}>
-      <StyledButtonBase
+      <SimpleButton
         onClick={() => {
           tabkit.openTab(
             {
@@ -51,8 +199,8 @@ export function FriendSidebar() {
       >
         <FontAwesomeIcon icon={faUserGroup} fixedWidth />
         <span>Friends</span>
-      </StyledButtonBase>
-      <StyledButtonBase
+      </SimpleButton>
+      <SimpleButton
         onClick={() => {
           tabkit.openTab(
             {
@@ -65,39 +213,72 @@ export function FriendSidebar() {
       >
         <FontAwesomeIcon icon={faEarthAmericas} fixedWidth />
         <span>Discover</span>
-      </StyledButtonBase>
+      </SimpleButton>
       <Heading fontSize="14px" p={2} color="gray.200">
         Direct Messages
       </Heading>
-      {dmFriends.length === 0 && (
+      {sortedDmFriends.length === 0 && (
         <Box px={4} color="gray.500">
           <Box>No DMs yet. Maybe add some friends?</Box>
         </Box>
       )}
-      {dmFriends.map((friend) => (
-        <StyledButtonBase
-          key={friend.id}
-          onClick={async () => {
-            const channel = await friend.openDm();
-            tabkit.openTab(
-              {
-                kind: 'textChannel',
-                key: channel.id,
-                channelId: channel.id,
-              },
-              false,
-            );
-          }}
-        >
-          <Avatar
-            className="avatar"
-            size={32}
-            src={friend.user.avatar ?? undefined}
-            userId={friend.user.id}
-          />
-          <div>{friend.user.name}</div>
-        </StyledButtonBase>
-      ))}
+      {sortedDmFriends.map((friend) => {
+        const channelId = friend.channelId!;
+        const channel = mikoto.channels._get(channelId);
+        const unread = isChannelUnread(channel?.lastUpdated, channelId);
+        const preview = previewsSnap.previews[channelId] as
+          | DmPreview
+          | undefined;
+        const timestampIso = preview?.timestamp ?? channel?.lastUpdated ?? null;
+        return (
+          <DmItem
+            key={friend.id}
+            unread={unread}
+            onClick={async () => {
+              const openedChannel = await friend.openDm();
+              tabkit.openTab(
+                {
+                  kind: 'textChannel',
+                  key: openedChannel.id,
+                  channelId: openedChannel.id,
+                },
+                false,
+              );
+              openedChannel.ack().catch(() => {});
+              ackChannel(openedChannel.id, new Date().toISOString());
+            }}
+          >
+            <Avatar
+              className="avatar"
+              size={40}
+              src={friend.user.avatar ?? undefined}
+              userId={friend.user.id}
+            />
+            <DmMeta>
+              <DmTopRow>
+                <DmName>{friend.user.name}</DmName>
+                {timestampIso && (
+                  <DmTimestamp unread={unread}>
+                    {formatRelativeTime(timestampIso)}
+                  </DmTimestamp>
+                )}
+              </DmTopRow>
+              <DmPreviewRow>
+                <DmPreviewText>
+                  {preview?.content === '' && preview.hasAttachments && (
+                    <FontAwesomeIcon
+                      icon={faImage}
+                      style={{ marginRight: 4 }}
+                    />
+                  )}
+                  {previewText(preview, selfId)}
+                </DmPreviewText>
+                {unread && <UnreadDot />}
+              </DmPreviewRow>
+            </DmMeta>
+          </DmItem>
+        );
+      })}
     </Box>
   );
 }

--- a/apps/client/src/components/sidebars/FriendSidebar.tsx
+++ b/apps/client/src/components/sidebars/FriendSidebar.tsx
@@ -157,19 +157,21 @@ export function FriendSidebar() {
   const friends = mikoto.relationships.friends;
   const dmFriends = friends.filter((f) => f.channelId);
 
+  const lastActivityIso = (channelId: string | null | undefined) => {
+    if (!channelId) return null;
+    const channel = mikoto.channels._get(channelId);
+    return (
+      previewsSnap.previews[channelId]?.timestamp ??
+      channel?.lastUpdated ??
+      null
+    );
+  };
+
   const sortedDmFriends = [...dmFriends].sort((a, b) => {
-    const aChannel = a.channelId
-      ? mikoto.channels._get(a.channelId)
-      : undefined;
-    const bChannel = b.channelId
-      ? mikoto.channels._get(b.channelId)
-      : undefined;
-    const aTime = aChannel?.lastUpdated
-      ? new Date(aChannel.lastUpdated).getTime()
-      : 0;
-    const bTime = bChannel?.lastUpdated
-      ? new Date(bChannel.lastUpdated).getTime()
-      : 0;
+    const aIso = lastActivityIso(a.channelId);
+    const bIso = lastActivityIso(b.channelId);
+    const aTime = aIso ? new Date(aIso).getTime() : 0;
+    const bTime = bIso ? new Date(bIso).getTime() : 0;
     return bTime - aTime;
   });
 
@@ -224,12 +226,11 @@ export function FriendSidebar() {
       )}
       {sortedDmFriends.map((friend) => {
         const channelId = friend.channelId!;
-        const channel = mikoto.channels._get(channelId);
-        const unread = isChannelUnread(channel?.lastUpdated, channelId);
         const preview = previewsSnap.previews[channelId] as
           | DmPreview
           | undefined;
-        const timestampIso = preview?.timestamp ?? channel?.lastUpdated ?? null;
+        const timestampIso = lastActivityIso(channelId);
+        const unread = isChannelUnread(timestampIso, channelId);
         return (
           <DmItem
             key={friend.id}

--- a/apps/client/src/components/surfaces/Messages/index.tsx
+++ b/apps/client/src/components/surfaces/Messages/index.tsx
@@ -196,14 +196,7 @@ function RealMessageView({ channel }: { channel: MikotoChannel }) {
     setMsgs((xs) => {
       if (xs === null) return null;
       setCurrentTypers((ts) => ts.filter((y) => y.userId !== x.author?.id));
-      if (channel.spaceId) {
-        mikoto.rest['channels.acknowledge'](undefined, {
-          params: {
-            spaceId: channel.spaceId,
-            channelId: channel.id,
-          },
-        }).then(() => {});
-      }
+      channel.ack().catch(() => {});
       setScrollToBottom(true);
       // Replace optimistic message if one exists for this user
       const optimisticIndex = xs.findIndex(

--- a/apps/client/src/store/dmPreviews.ts
+++ b/apps/client/src/store/dmPreviews.ts
@@ -51,9 +51,10 @@ export async function loadDmPreviews(
   await Promise.allSettled(
     channelIds.map(async (channelId) => {
       if (dmPreviewStore.previews[channelId]) return;
-      const channel = mikoto.channels._get(channelId);
-      if (!channel) return;
-      const msgs = await channel.listMessages(1, null);
+      const msgs = await mikoto.rest['dm.messages.list']({
+        params: { channelId },
+        queries: { limit: 1, cursor: null },
+      });
       const last = msgs[msgs.length - 1];
       if (last) {
         setDmPreview(channelId, last);

--- a/apps/client/src/store/dmPreviews.ts
+++ b/apps/client/src/store/dmPreviews.ts
@@ -1,0 +1,63 @@
+import { MessageExt, MikotoClient } from '@mikoto-io/mikoto.js';
+import { proxy } from 'valtio/vanilla';
+
+export interface DmPreview {
+  content: string;
+  timestamp: string;
+  authorId: string | null;
+  authorName: string | null;
+  hasAttachments: boolean;
+}
+
+export const dmPreviewStore = proxy<{ previews: Record<string, DmPreview> }>({
+  previews: {},
+});
+
+function toPreview(msg: MessageExt): DmPreview {
+  return {
+    content: msg.content,
+    timestamp: msg.timestamp,
+    authorId: msg.authorId ?? null,
+    authorName: msg.author?.name ?? null,
+    hasAttachments: (msg.attachments?.length ?? 0) > 0,
+  };
+}
+
+export function setDmPreview(channelId: string, msg: MessageExt) {
+  const existing = dmPreviewStore.previews[channelId];
+  if (existing) {
+    const existingT = new Date(existing.timestamp).getTime();
+    const incomingT = new Date(msg.timestamp).getTime();
+    if (incomingT < existingT) return;
+  }
+  dmPreviewStore.previews[channelId] = toPreview(msg);
+}
+
+export function updateDmPreview(channelId: string, msg: MessageExt) {
+  const existing = dmPreviewStore.previews[channelId];
+  if (!existing || existing.timestamp === msg.timestamp) {
+    dmPreviewStore.previews[channelId] = toPreview(msg);
+  }
+}
+
+export function clearDmPreview(channelId: string) {
+  delete dmPreviewStore.previews[channelId];
+}
+
+export async function loadDmPreviews(
+  mikoto: MikotoClient,
+  channelIds: string[],
+) {
+  await Promise.allSettled(
+    channelIds.map(async (channelId) => {
+      if (dmPreviewStore.previews[channelId]) return;
+      const channel = mikoto.channels._get(channelId);
+      if (!channel) return;
+      const msgs = await channel.listMessages(1, null);
+      const last = msgs[msgs.length - 1];
+      if (last) {
+        setDmPreview(channelId, last);
+      }
+    }),
+  );
+}

--- a/apps/client/src/store/dmPreviews.ts
+++ b/apps/client/src/store/dmPreviews.ts
@@ -2,6 +2,7 @@ import { MessageExt, MikotoClient } from '@mikoto-io/mikoto.js';
 import { proxy } from 'valtio/vanilla';
 
 export interface DmPreview {
+  messageId: string;
   content: string;
   timestamp: string;
   authorId: string | null;
@@ -15,6 +16,7 @@ export const dmPreviewStore = proxy<{ previews: Record<string, DmPreview> }>({
 
 function toPreview(msg: MessageExt): DmPreview {
   return {
+    messageId: msg.id,
     content: msg.content,
     timestamp: msg.timestamp,
     authorId: msg.authorId ?? null,
@@ -35,13 +37,29 @@ export function setDmPreview(channelId: string, msg: MessageExt) {
 
 export function updateDmPreview(channelId: string, msg: MessageExt) {
   const existing = dmPreviewStore.previews[channelId];
-  if (!existing || existing.timestamp === msg.timestamp) {
+  if (!existing || existing.messageId === msg.id) {
     dmPreviewStore.previews[channelId] = toPreview(msg);
   }
 }
 
 export function clearDmPreview(channelId: string) {
   delete dmPreviewStore.previews[channelId];
+}
+
+export async function refreshDmPreview(
+  mikoto: MikotoClient,
+  channelId: string,
+) {
+  const msgs = await mikoto.rest['dm.messages.list']({
+    params: { channelId },
+    queries: { limit: 1, cursor: null },
+  });
+  const last = msgs[msgs.length - 1];
+  if (last) {
+    dmPreviewStore.previews[channelId] = toPreview(last);
+  } else {
+    clearDmPreview(channelId);
+  }
 }
 
 export async function loadDmPreviews(

--- a/apps/client/src/store/unreads.ts
+++ b/apps/client/src/store/unreads.ts
@@ -48,6 +48,13 @@ export async function loadAcksForAllSpaces(mikoto: MikotoClient) {
   );
 }
 
+export async function loadAcksForDms(mikoto: MikotoClient) {
+  const unreads = await mikoto.rest['dm.unreads']();
+  for (const u of unreads) {
+    ackStore.acks[u.channelId] = u.timestamp;
+  }
+}
+
 export function ackChannel(channelId: string, timestamp: string) {
   ackStore.acks[channelId] = timestamp;
 }

--- a/apps/client/src/views/MikotoClientProvider.tsx
+++ b/apps/client/src/views/MikotoClientProvider.tsx
@@ -8,9 +8,15 @@ import { notifyFromMessage } from '@/functions/notify';
 import { AuthContext, MikotoContext } from '@/hooks';
 import { authClient } from '@/store/authClient';
 import {
+  clearDmPreview,
+  setDmPreview,
+  updateDmPreview,
+} from '@/store/dmPreviews';
+import {
   ackChannel,
   getSpaceNotificationLevel,
   loadAcksForAllSpaces,
+  loadAcksForDms,
   loadNotificationPreferences,
 } from '@/store/unreads';
 
@@ -21,6 +27,10 @@ function registerNotifications(mikoto: MikotoClient) {
   mikoto.ws.on('messages.onCreate', (msg) => {
     const channel = mikoto.channels._get(msg.channelId);
     if (channel) channel.lastUpdated = msg.timestamp;
+
+    if (!channel?.spaceId) {
+      setDmPreview(msg.channelId, msg);
+    }
 
     if (msg.authorId === mikoto.user.me?.id) {
       ackChannel(msg.channelId, msg.timestamp);
@@ -38,6 +48,20 @@ function registerNotifications(mikoto: MikotoClient) {
     if (isViewingChannel) {
       channel.ack();
       ackChannel(msg.channelId, msg.timestamp);
+    }
+  });
+
+  mikoto.ws.on('messages.onUpdate', (msg) => {
+    const channel = mikoto.channels._get(msg.channelId);
+    if (!channel?.spaceId) {
+      updateDmPreview(msg.channelId, msg);
+    }
+  });
+
+  mikoto.ws.on('messages.onDelete', (key) => {
+    const channel = mikoto.channels._get(key.channelId);
+    if (!channel?.spaceId) {
+      clearDmPreview(key.channelId);
     }
   });
 }
@@ -70,7 +94,10 @@ export function MikotoClientProvider({
         await Promise.all([mi.spaces.list(), mi.user.load()]);
         await loadNotificationPreferences(mi);
         registerNotifications(mi);
-        await loadAcksForAllSpaces(mi);
+        await Promise.allSettled([
+          loadAcksForAllSpaces(mi),
+          loadAcksForDms(mi),
+        ]);
         setMikoto(mi);
         return;
       } catch (e) {

--- a/apps/client/src/views/MikotoClientProvider.tsx
+++ b/apps/client/src/views/MikotoClientProvider.tsx
@@ -9,6 +9,8 @@ import { AuthContext, MikotoContext } from '@/hooks';
 import { authClient } from '@/store/authClient';
 import {
   clearDmPreview,
+  dmPreviewStore,
+  refreshDmPreview,
   setDmPreview,
   updateDmPreview,
 } from '@/store/dmPreviews';
@@ -60,9 +62,14 @@ function registerNotifications(mikoto: MikotoClient) {
 
   mikoto.ws.on('messages.onDelete', (key) => {
     const channel = mikoto.channels._get(key.channelId);
-    if (!channel?.spaceId) {
+    if (channel?.spaceId) return;
+
+    const existing = dmPreviewStore.previews[key.channelId];
+    if (!existing || existing.messageId !== key.messageId) return;
+
+    refreshDmPreview(mikoto, key.channelId).catch(() => {
       clearDmPreview(key.channelId);
-    }
+    });
   });
 }
 

--- a/apps/superego/api.json
+++ b/apps/superego/api.json
@@ -986,6 +986,51 @@
         }
       }
     },
+    "/dm/unreads": {
+      "get": {
+        "tags": [
+          "DM"
+        ],
+        "summary": "List DM Unreads",
+        "operationId": "dm.unreads",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ChannelUnread"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dm/{channelId}/ack": {
+      "post": {
+        "tags": [
+          "DM"
+        ],
+        "summary": "Acknowledge DM Channel",
+        "operationId": "dm.acknowledge",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "null"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/push/config": {
       "get": {
         "tags": [

--- a/apps/superego/src/entities/channel.rs
+++ b/apps/superego/src/entities/channel.rs
@@ -100,6 +100,26 @@ impl ChannelUnread {
         .await?;
         Ok(unreads)
     }
+
+    /// List all DM-channel unreads for a user (channels with no space, where
+    /// the user has a relationship row referencing the channel).
+    pub async fn list_dms_by_user<'c, X: sqlx::PgExecutor<'c>>(
+        user_id: Uuid,
+        db: X,
+    ) -> Result<Vec<Self>, Error> {
+        let unreads = sqlx::query_as(
+            r##"
+            SELECT cu.* FROM "ChannelUnread" cu
+            JOIN "Channel" c ON cu."channelId" = c."id"
+            JOIN "Relationship" r ON r."channelId" = c."id" AND r."userId" = $1
+            WHERE cu."userId" = $1 AND c."spaceId" IS NULL
+            "##,
+        )
+        .bind(user_id)
+        .fetch_all(db)
+        .await?;
+        Ok(unreads)
+    }
 }
 
 impl Channel {

--- a/apps/superego/src/routes/dm.rs
+++ b/apps/superego/src/routes/dm.rs
@@ -9,14 +9,15 @@ use uuid::Uuid;
 use crate::{
     db::db,
     entities::{
-        Channel, Message, MessageAttachment, MessageAttachmentInput, MessageExt, MessageKey,
-        MessagePatch, Relationship,
+        Channel, ChannelUnread, Message, MessageAttachment, MessageAttachmentInput, MessageExt,
+        MessageKey, MessagePatch, Relationship,
     },
     error::Error,
     functions::{
         jwt::Claims,
         pubsub::emit_event,
         push::{self, PushPayload},
+        time::Timestamp,
     },
     routes::{router::AppRouter, ws::state::State},
 };
@@ -196,6 +197,19 @@ async fn delete(
     Ok(().into())
 }
 
+async fn acknowledge(claim: Claims, Path(channel_id): Path<Uuid>) -> Result<Json<()>, Error> {
+    let user_id: Uuid = claim.sub.parse()?;
+    verify_dm_access(channel_id, user_id).await?;
+    ChannelUnread::upsert(channel_id, user_id, Timestamp::now(), db()).await?;
+    Ok(().into())
+}
+
+async fn list_unreads(claim: Claims) -> Result<Json<Vec<ChannelUnread>>, Error> {
+    let user_id: Uuid = claim.sub.parse()?;
+    let unreads = ChannelUnread::list_dms_by_user(user_id, db()).await?;
+    Ok(unreads.into())
+}
+
 static TAG: &str = "DM";
 
 pub fn router() -> AppRouter<State> {
@@ -230,6 +244,26 @@ pub fn router() -> AppRouter<State> {
                 o.tag(TAG)
                     .id("dm.messages.delete")
                     .summary("Delete DM Message")
+            }),
+        )
+}
+
+pub fn channel_router() -> AppRouter<State> {
+    AppRouter::new()
+        .route(
+            "/unreads",
+            get_with(list_unreads, |o| {
+                o.tag(TAG)
+                    .id("dm.unreads")
+                    .summary("List DM Unreads")
+            }),
+        )
+        .route(
+            "/:channelId/ack",
+            post_with(acknowledge, |o| {
+                o.tag(TAG)
+                    .id("dm.acknowledge")
+                    .summary("Acknowledge DM Channel")
             }),
         )
 }

--- a/apps/superego/src/routes/mod.rs
+++ b/apps/superego/src/routes/mod.rs
@@ -85,6 +85,7 @@ fn build_app_router() -> AppRouter<State> {
         .nest("users", "/users", users::router())
         .nest("relations", "/relations", users::relations::router())
         .nest("dm_messages", "/dm/:channelId/messages", dm::router())
+        .nest("dm_channels", "/dm", dm::channel_router())
         .nest("push", "/push", push::router())
         .nest("spaces", "/spaces", spaces::router())
         .nest("channels", "/spaces/:spaceId/channels", channels::router())

--- a/packages/mikoto.js/src/api.gen.ts
+++ b/packages/mikoto.js/src/api.gen.ts
@@ -266,6 +266,13 @@ export type MessageSendPayload = z.infer<typeof MessageSendPayload>;
 export const MessageEditPayload = z.object({ content: z.string() });
 export type MessageEditPayload = z.infer<typeof MessageEditPayload>;
 
+export const ChannelUnread = z.object({
+  channelId: z.string().uuid(),
+  timestamp: Timestamp.datetime({ offset: true }),
+  userId: z.string().uuid(),
+});
+export type ChannelUnread = z.infer<typeof ChannelUnread>;
+
 export const PushConfig = z
   .object({ publicKey: z.union([z.string(), z.null()]) })
   .partial();
@@ -355,13 +362,6 @@ export const ChannelPatch = z
   .object({ name: z.union([z.string(), z.null()]) })
   .partial();
 export type ChannelPatch = z.infer<typeof ChannelPatch>;
-
-export const ChannelUnread = z.object({
-  channelId: z.string().uuid(),
-  timestamp: Timestamp.datetime({ offset: true }),
-  userId: z.string().uuid(),
-});
-export type ChannelUnread = z.infer<typeof ChannelUnread>;
 
 export const MessageSendPayload2 = z.object({
   attachments: z.array(MessageAttachmentInput).optional().default([]),
@@ -544,6 +544,7 @@ export const schemas = {
   MessageAttachmentInput,
   MessageSendPayload,
   MessageEditPayload,
+  ChannelUnread,
   PushConfig,
   SubscribePayload,
   SubscribeResponse,
@@ -559,7 +560,6 @@ export const schemas = {
   NotificationPreferencePayload,
   ChannelCreatePayload,
   ChannelPatch,
-  ChannelUnread,
   MessageSendPayload2,
   MessageEditPayload2,
   VoiceToken,
@@ -786,6 +786,13 @@ const endpoints = makeApi([
     response: TokenPair,
   },
   {
+    method: "post",
+    path: "/dm/:channelId/ack",
+    alias: "dm.acknowledge",
+    requestFormat: "json",
+    response: z.null(),
+  },
+  {
     method: "get",
     path: "/dm/:channelId/messages/",
     alias: "dm.messages.list",
@@ -838,6 +845,13 @@ const endpoints = makeApi([
       },
     ],
     response: MessageExt,
+  },
+  {
+    method: "get",
+    path: "/dm/unreads",
+    alias: "dm.unreads",
+    requestFormat: "json",
+    response: z.array(ChannelUnread),
   },
   {
     method: "get",

--- a/packages/mikoto.js/src/managers/channel/index.ts
+++ b/packages/mikoto.js/src/managers/channel/index.ts
@@ -67,12 +67,17 @@ export class MikotoChannel extends ZSchema(Channel) {
   }
 
   async ack() {
-    if (!this.spaceId) return;
-    await this.client.rest['channels.acknowledge'](undefined, {
-      params: {
-        spaceId: this.spaceId,
-        channelId: this.id,
-      },
+    if (this.spaceId) {
+      await this.client.rest['channels.acknowledge'](undefined, {
+        params: {
+          spaceId: this.spaceId,
+          channelId: this.id,
+        },
+      });
+      return;
+    }
+    await this.client.rest['dm.acknowledge'](undefined, {
+      params: { channelId: this.id },
     });
   }
 


### PR DESCRIPTION
## Summary
This PR enhances the Direct Messages sidebar by displaying message previews, timestamps, and unread indicators for each DM conversation. It also adds backend support for tracking DM read status.

## Key Changes

### Frontend (Client)
- **Enhanced DM List UI**: Redesigned DM items to show:
  - Message preview text with author prefix (e.g., "You: Hello")
  - Relative timestamps (now, 5m, 2h, 3d, etc.)
  - Unread status indicator (dot) and styling
  - Attachment icon when message contains attachments
  - Avatar size increased from 32px to 40px

- **New DM Preview Store** (`dmPreviews.ts`):
  - Created `dmPreviewStore` to cache the latest message preview per DM channel
  - Implemented `loadDmPreviews()` to fetch last message from each channel
  - Added helper functions: `setDmPreview()`, `updateDmPreview()`, `clearDmPreview()`

- **Unread Tracking Integration**:
  - Integrated with existing `ackStore` to track read status per channel
  - Added `loadAcksForDms()` to load DM unread state on app startup
  - DM items now sorted by `lastUpdated` timestamp (most recent first)
  - Clicking a DM now calls `ackChannel()` to mark it as read

- **Real-time Updates**:
  - Registered WebSocket listeners for message create/update/delete events
  - DM previews update automatically when new messages arrive
  - Previews clear when messages are deleted

### Backend (Superego)
- **New DM Unread Endpoints**:
  - `GET /dm/unreads` - List all unread DM channels for the authenticated user
  - `POST /dm/{channelId}/ack` - Mark a DM channel as read

- **Database Query**:
  - Added `ChannelUnread::list_dms_by_user()` to fetch unreads for DM channels only (channels with no `spaceId`)

### SDK (mikoto.js)
- **Channel Acknowledgment Logic**:
  - Updated `MikotoChannel.ack()` to route to appropriate endpoint based on channel type (space vs DM)
  - Maintains backward compatibility with space channel acknowledgment

- **API Schema**:
  - Added `ChannelUnread` schema to DM endpoints
  - Registered new `/dm/unreads` and `/dm/{channelId}/ack` endpoints

## Implementation Details
- Relative time formatting handles edge cases (same year, different years)
- Preview text gracefully handles missing content, attachments, and self-authored messages
- DM preview loading uses `Promise.allSettled()` to prevent one failed channel from blocking others
- Unread styling uses primary color for timestamps and bold font weight for unread items
- All new styled components follow existing design patterns with proper overflow handling

https://claude.ai/code/session_01VS1LaStXDertSFUyWg6k43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DM sidebar now shows per-conversation message previews, compact relative timestamps, and sorts by recent activity.
  * Previews label messages you sent with "You:" and show an attachment icon for attachment-only messages.
  * Background loading and real-time updates keep DM previews current and populate missing previews.
  * Unread indicators and more reliable read/ack handling when opening DMs and after sending messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->