### PR TITLE
Lazy-load members for visible message authors and typers

### DIFF
--- a/apps/client/src/components/surfaces/Messages/TypingIndicator.tsx
+++ b/apps/client/src/components/surfaces/Messages/TypingIndicator.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@chakra-ui/react';
 import { MikotoChannel } from '@mikoto-io/mikoto.js';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useInterval, useMikoto } from '@/hooks';
 import { TypingDots } from '@/ui';
@@ -42,6 +42,14 @@ export function TypingIndicator({ typers, channel }: TypingIndicatorProps) {
   const space = channel.spaceId
     ? mikoto.spaces._get(channel.spaceId)
     : undefined;
+
+  useEffect(() => {
+    if (!space) return;
+    typers.forEach((t) => {
+      space.members.ensureLoaded(t.userId);
+    });
+  }, [space, typers]);
+
   const humanNames: string[] = [];
   const botNames: string[] = [];
 

--- a/packages/mikoto.js/src/managers/message.ts
+++ b/packages/mikoto.js/src/managers/message.ts
@@ -29,7 +29,15 @@ export class MikotoMessage extends ZSchema(MessageExt) {
 
   get member() {
     if (!this.authorId) return undefined;
-    return this.channel?.space?.members._get(this.authorId);
+    const members = this.channel?.space?.members;
+    if (!members) return undefined;
+    const cached = members._get(this.authorId);
+    if (cached) return cached;
+    // Lazy-load the member on first access. The valtio proxy will trigger
+    // a re-render once the cache is populated. Internal dedup prevents
+    // duplicate requests for the same user.
+    members.ensureLoaded(this.authorId);
+    return undefined;
   }
 
   async edit(content: string) {

--- a/packages/mikoto.js/src/managers/space/member.ts
+++ b/packages/mikoto.js/src/managers/space/member.ts
@@ -88,6 +88,8 @@ export class MemberManager extends CachedManager<MikotoMember> {
   hasMore = true;
   private nextCursor?: string;
   private fetching = false;
+  private inflight = ref(new Map<string, Promise<MikotoMember | undefined>>());
+  private knownMissing = ref(new Set<string>());
 
   constructor(public space: MikotoSpace) {
     super(space.client);
@@ -96,6 +98,7 @@ export class MemberManager extends CachedManager<MikotoMember> {
 
   override _insert(data: MikotoMember) {
     this.cache.set(data.userId, data);
+    this.knownMissing.delete(data.userId);
   }
 
   reset() {
@@ -103,6 +106,8 @@ export class MemberManager extends CachedManager<MikotoMember> {
     this.hasMore = true;
     this.nextCursor = undefined;
     this.fetching = false;
+    this.inflight.clear();
+    this.knownMissing.clear();
   }
 
   async list() {
@@ -123,6 +128,39 @@ export class MemberManager extends CachedManager<MikotoMember> {
     } finally {
       this.fetching = false;
     }
+  }
+
+  /**
+   * Ensure a member is loaded into the cache, fetching it if missing.
+   * Deduplicates concurrent calls and remembers users that aren't members
+   * so we don't retry forever.
+   */
+  ensureLoaded(userId: string): Promise<MikotoMember | undefined> {
+    const existing = this.cache.get(userId);
+    if (existing) return Promise.resolve(existing);
+    if (this.knownMissing.has(userId)) return Promise.resolve(undefined);
+
+    const pending = this.inflight.get(userId);
+    if (pending) return pending;
+
+    const promise = (async () => {
+      try {
+        const data = await this.client.rest['members.get']({
+          params: { spaceId: this.space.id, userId },
+        });
+        const member = new MikotoMember(data, this.client);
+        this._insert(member);
+        return member;
+      } catch {
+        this.knownMissing.add(userId);
+        return undefined;
+      } finally {
+        this.inflight.delete(userId);
+      }
+    })();
+
+    this.inflight.set(userId, promise);
+    return promise;
   }
 
   static _subscribe(client: MikotoClient) {

--- a/packages/mikoto.js/src/managers/space/member.ts
+++ b/packages/mikoto.js/src/managers/space/member.ts
@@ -151,8 +151,12 @@ export class MemberManager extends CachedManager<MikotoMember> {
         const member = new MikotoMember(data, this.client);
         this._insert(member);
         return member;
-      } catch {
-        this.knownMissing.add(userId);
+      } catch (err) {
+        // Only treat a definitive 404 as "not a member" — transient
+        // failures (network drops, 5xx, timeouts) must stay retryable.
+        const status = (err as { response?: { status?: number } } | undefined)
+          ?.response?.status;
+        if (status === 404) this.knownMissing.add(userId);
         return undefined;
       } finally {
         this.inflight.delete(userId);


### PR DESCRIPTION
## Summary

In larger spaces (the bug report came from one with 381 members), users past the first paginated page of the member list rendered with white names instead of role colors, and typers showed as "Unknown". The member cache was previously only populated by paginated `members.list` calls and websocket events — and the next page was only fetched when the user opened the members sidebar, which was a fragile place to hang member loading off of.

This change makes the cache fill itself on demand: any rendered message or active typer triggers a single `members.get` for its user. Concurrent requests for the same user are deduped, and users that aren't actually members are remembered so we don't retry forever.

## Test plan

- [ ] Open a space with >100 members, scroll to messages from authors past the first page — names should resolve to their role colors within a moment of rendering
- [ ] Have someone past the first page start typing — typing indicator should show their real name, not "Unknown"
- [ ] Verify deleted/former members don't cause repeated network requests
- [ ] Verify normal paginated load via the members sidebar still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typing indicator now proactively ensures member info is available so participant names load more reliably.
  * On-demand member loading with request deduplication to populate member cache when needed.

* **Bug Fixes**
  * Prevents duplicate concurrent requests for the same users.
  * Stops repeated retries for unavailable members and improves handling of transient fetch errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->