### PR TITLE
👩‍💻 add local dev -> prod server dev flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ docker compose up -d # Run auxiliary services
 just run-core # runs the base scripts
 ```
 
+#### Frontend-only against production
+
+If you're iterating on client UI and don't need a local backend, you can
+point the dev client at the production API instead:
+
+```sh
+just run-client-prod
+```
+
+This runs the client on `http://localhost:3510` and proxies API, media,
+and WebSocket traffic through to the production services same-origin
+(no local Docker, superego, or migrations required). See
+[apps/client/docs/PROD-BACKEND-DEV.md](./apps/client/docs/PROD-BACKEND-DEV.md)
+for details.
+
 ### Build
 
 To build all apps and packages, run the following command:

--- a/apps/client/.env.prod-backend
+++ b/apps/client/.env.prod-backend
@@ -1,0 +1,12 @@
+# Env preset for running the local dev client against the production
+# backend. Activated by `pnpm dev:prod-backend` (vite --mode prod-backend).
+#
+# URLs point at the Vite dev server's own origin; `server.proxy` in
+# vite.config.ts forwards /__api and /__media to the prod services.
+# This keeps the browser same-origin, sidestepping CORS entirely.
+#
+# Assumes the dev server runs on http://localhost:3510 (PORT=3510 in .env).
+
+PUBLIC_SERVER_URL=http://localhost:3510/__api
+PUBLIC_MEDIASERVER_URL=http://localhost:3510/__media
+PUBLIC_FRONTEND_URL=https://platform.mikoto.io

--- a/apps/client/docs/PROD-BACKEND-DEV.md
+++ b/apps/client/docs/PROD-BACKEND-DEV.md
@@ -1,0 +1,74 @@
+# Running the dev client against the production backend
+
+A design-engineer devflow for iterating on the client UI against real
+production data (real spaces, real users, real messages) without standing
+up a local superego.
+
+## TL;DR
+
+```sh
+just run-client-prod
+# open http://localhost:3510
+```
+
+Under the hood this runs `moon run client:dev.prod-backend`, which runs
+`vite --mode prod-backend` from `apps/client/`.
+
+You'll log in with your regular prod Mikoto account. All REST calls,
+WebSockets, collab (Y.js), and media uploads/downloads transparently
+proxy through the Vite dev server to the prod instance.
+
+## How it works
+
+Going direct from `localhost` to `https://server.platform.mikoto.io` would hit CORS —
+the prod superego strictly allows only its own `WEB_URL` origin. Instead
+of loosening CORS, we keep the browser same-origin by running everything
+through Vite's dev-server proxy:
+
+```
+browser ──► http://localhost:3510/__api/...     ──► https://server.platform.mikoto.io/...
+browser ──► ws://localhost:3510/__api/ws        ──► wss://server.platform.mikoto.io/ws
+browser ──► ws://localhost:3510/__api/collab    ──► wss://server.platform.mikoto.io/collab
+browser ──► http://localhost:3510/__media/...   ──► https://cdn.platform.mikoto.io/...
+```
+
+Three things make this work:
+
+1. **`apps/client/.env.prod-backend`** sets `PUBLIC_SERVER_URL` and
+   `PUBLIC_MEDIASERVER_URL` to the dev server's own origin with a
+   `/__api` / `/__media` prefix.
+2. **`server.proxy` in `vite.config.ts`** rewrites those prefixes away
+   and forwards to the prod origins, with `changeOrigin: true`, `secure:
+   true`, and `ws: true` so WebSocket upgrades (main socket +
+   `y-websocket` collab) pass through.
+3. **`dev.prod-backend` moon task** (declared in `apps/client/moon.yml`)
+   runs `vite --mode prod-backend` so Vite picks up the env file.
+   `just run-client-prod` is the top-level wrapper.
+
+## Pointing at a different backend (staging, a coworker's tunnel, etc.)
+
+Override the proxy targets without editing the committed config:
+
+```sh
+PROXY_API_TARGET=https://server-staging.platform.mikoto.io \
+PROXY_MEDIA_TARGET=https://cdn-staging.platform.mikoto.io \
+  just run-client-prod
+```
+
+## Gotchas
+
+- **Port 3510 is required.** `.env.prod-backend` hard-codes
+  `http://localhost:3510/__api` because the mikoto.js client parses it
+  with `new URL(...)` and needs an absolute URL. Make sure `PORT=3510`
+  is set in the repo-root `.env` (it is by default).
+- **Invite links use the prod frontend URL.** `PUBLIC_FRONTEND_URL` is
+  set to `https://platform.mikoto.io` so invites you generate locally
+  point at prod, which is almost always what you want. If you need
+  local-facing invite links, override `PUBLIC_FRONTEND_URL` in a
+  `.env.prod-backend.local` (gitignored).
+- **This is the real prod DB.** Every action (sending a message,
+  deleting a channel, changing your avatar) is real. Design against
+  throwaway spaces if you're testing destructive flows.
+- **Service workers:** push notifications won't meaningfully work
+  against prod from localhost — the SW is scoped to localhost and
+  VAPID endpoints will be tied to this origin.

--- a/apps/client/moon.yml
+++ b/apps/client/moon.yml
@@ -6,3 +6,10 @@ tasks:
     command: 'tsc --noEmit'
     deps:
       - 'mikoto.js:build'
+
+  # Run the client dev server against the production backend via a
+  # same-origin Vite proxy (see apps/client/docs/PROD-BACKEND-DEV.md).
+  # Intended as a design-engineer devflow: no local superego needed.
+  dev.prod-backend:
+    command: 'vite --mode prod-backend'
+    preset: 'server'

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -4,17 +4,39 @@ import * as dotenv from 'dotenv';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
 import { visualizer } from 'rollup-plugin-visualizer';
-import { defineConfig } from 'vite';
+import { defineConfig, type ProxyOptions } from 'vite';
 
 // import { VitePWA } from 'vite-plugin-pwa';
 
 dotenv.config();
+
+// When running against the production backend (`vite --mode prod-backend`),
+// we route /__api and /__media through the dev server so the browser stays
+// same-origin and CORS is a non-issue. The target URLs can be overridden
+// per-developer via PROXY_API_TARGET / PROXY_MEDIA_TARGET env vars (e.g.
+// to point at a staging instance) without editing this file.
+const PROD_BACKEND_PROXY: Record<string, ProxyOptions> = {
+  '/__api': {
+    target: process.env.PROXY_API_TARGET || 'https://server.platform.mikoto.io',
+    changeOrigin: true,
+    secure: true,
+    ws: true,
+    rewrite: (p) => p.replace(/^\/__api/, ''),
+  },
+  '/__media': {
+    target: process.env.PROXY_MEDIA_TARGET || 'https://cdn.platform.mikoto.io',
+    changeOrigin: true,
+    secure: true,
+    rewrite: (p) => p.replace(/^\/__media/, ''),
+  },
+};
 
 export default ({ mode }: { mode: string }) =>
   defineConfig({
     server: {
       host: process.env.HOST || undefined,
       port: parseInt(process.env.PORT || '', 10) || undefined,
+      proxy: mode === 'prod-backend' ? PROD_BACKEND_PROXY : undefined,
     },
     build: {
       target: 'es2020',

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -1,14 +1,11 @@
 /// <reference types="vitest" />
 import react from '@vitejs/plugin-react';
-import * as dotenv from 'dotenv';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
 import { visualizer } from 'rollup-plugin-visualizer';
-import { defineConfig, type ProxyOptions } from 'vite';
+import { defineConfig, loadEnv, type ProxyOptions } from 'vite';
 
 // import { VitePWA } from 'vite-plugin-pwa';
-
-dotenv.config();
 
 // When running against the production backend (`vite --mode prod-backend`),
 // we route /__api and /__media through the dev server so the browser stays
@@ -31,11 +28,17 @@ const PROD_BACKEND_PROXY: Record<string, ProxyOptions> = {
   },
 };
 
-export default ({ mode }: { mode: string }) =>
-  defineConfig({
+export default ({ mode }: { mode: string }) => {
+  // Use Vite's loadEnv so .env.[mode] correctly overrides .env. We avoid
+  // calling dotenv.config() at module top-level because it pre-populates
+  // process.env, and Vite's own env loading then treats those process.env
+  // values as authoritative — clobbering the mode-specific overrides
+  // (e.g. PUBLIC_MEDIASERVER_URL in .env.prod-backend).
+  const env = loadEnv(mode, process.cwd(), '');
+  return defineConfig({
     server: {
-      host: process.env.HOST || undefined,
-      port: parseInt(process.env.PORT || '', 10) || undefined,
+      host: env.HOST || undefined,
+      port: parseInt(env.PORT || '', 10) || undefined,
       proxy: mode === 'prod-backend' ? PROD_BACKEND_PROXY : undefined,
     },
     build: {
@@ -75,3 +78,4 @@ export default ({ mode }: { mode: string }) =>
     },
     envPrefix: ['MIKOTO_', 'PUBLIC_'],
   });
+};

--- a/justfile
+++ b/justfile
@@ -1,5 +1,12 @@
 run-core:
     moon :start --query "tag~core-app"
+
+# Run only the client dev server, pointed at the production backend.
+# Designed for frontend/design-engineer iteration — no local superego,
+# redis, postgres, or media stack required. See
+# apps/client/docs/PROD-BACKEND-DEV.md for how the proxy works.
+run-client-prod:
+    moon run client:dev.prod-backend
 # Run database migrations for superego
 migrate:
     cd apps/superego && cargo run --bin migrate

--- a/packages/mikoto.js/src/MikotoClient.ts
+++ b/packages/mikoto.js/src/MikotoClient.ts
@@ -55,8 +55,9 @@ export class MikotoClient {
     this.timeOfLastRefresh = new Date();
     const websocketUrl = new URL(this.options.url);
     websocketUrl.protocol = websocketUrl.protocol.replace('http', 'ws');
+    const basePath = websocketUrl.pathname.replace(/\/+$/, '');
     this.ws = new WebsocketApi({
-      url: `${websocketUrl.origin}/ws`,
+      url: `${websocketUrl.origin}${basePath}/ws`,
       token: this.token,
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2899,6 +2899,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@use-it/event-listener@0.1.7':
     resolution: {integrity: sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run the local client against the production backend via a local proxy (includes env preset, run target, and dev task to start the proxied client).
  * WebSocket URL handling now respects REST URL path prefixes for correct websocket connections.

* **Documentation**
  * Added comprehensive docs for the production-backend dev workflow, run command, proxy behavior, and known caveats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->