### PR TITLE
Pin document action bar and restyle edit toggle

### DIFF
--- a/apps/client/src/components/surfaces/Documents/index.tsx
+++ b/apps/client/src/components/surfaces/Documents/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {
   faCircleNotch,
   faFileLines,
+  faPencil,
   faPencilSquare,
   faSave,
 } from '@fortawesome/free-solid-svg-icons';
@@ -177,7 +178,6 @@ const EditorWrapper = styled.div`
 
   .editor-input {
     outline: none;
-    min-height: calc(100dvh - 200px);
   }
 
   blockquote {
@@ -280,15 +280,12 @@ function MikotoContentEditable({
 function DocumentActions({ children }: PropsWithChildren) {
   return (
     <Flex
-      position="sticky"
-      top={0}
-      zIndex={1}
+      flexShrink={0}
       bg="surface"
       borderBottom="1px solid"
       borderBottomColor="gray.650"
       px={4}
       py={2}
-      mb={8}
       align="center"
       justify="space-between"
     >
@@ -555,7 +552,7 @@ export default function DocumentSurface({ channelId }: { channelId: string }) {
   const lastEdited = useRelativeTime(channel.lastUpdatedDate);
 
   return (
-    <Surface scroll>
+    <Surface>
       <TabName
         name={channel.name}
         icon={channel.space?.icon ?? faFileLines}
@@ -581,7 +578,8 @@ export default function DocumentSurface({ channelId }: { channelId: string }) {
               offsetOptions={[0, 4]}
             >
               <Button
-                variant="ghost"
+                colorPalette="blue"
+                size="sm"
                 p={2}
                 onClick={() => {
                   if (documentSnap.type === 'read') {
@@ -593,7 +591,10 @@ export default function DocumentSurface({ channelId }: { channelId: string }) {
                 }}
               >
                 {documentSnap.type === 'read' ? (
-                  <FontAwesomeIcon icon={faPencilSquare} />
+                  <>
+                    <FontAwesomeIcon icon={faPencil} />
+                    Edit
+                  </>
                 ) : documentSnap.save === 'saving' ? (
                   <FontAwesomeIcon icon={faCircleNotch} spin />
                 ) : (
@@ -604,7 +605,7 @@ export default function DocumentSurface({ channelId }: { channelId: string }) {
           </Group>
         </Flex>
       </DocumentActions>
-      <Box px={8} pb={32}>
+      <Box flex={1} overflowY="auto" px={8} pt={8} pb={32}>
         {documentSnap.type === 'read' && (
           <Box
             onDoubleClick={() => {


### PR DESCRIPTION
## Summary
- Moves the scroll container from the `Surface` down to the inner content `Box` so the action bar can stay pinned at the top without `position: sticky`, eliminating the bottom margin hack and the forced editor min-height.
- Restyles the read-mode toggle as a labelled `Edit` button (blue palette, small size, pencil icon) to make the affordance more obvious.

## Test plan
- [ ] Open a document; confirm the action bar stays fixed while the body scrolls.
- [ ] Toggle between read and edit modes; verify the button label/icon swap and saving spinner still render correctly.
- [ ] Check short documents still render without awkward whitespace below the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated edit button with pencil icon and "Edit" label for improved clarity
  * Adjusted document header layout and positioning
  * Enhanced editor sizing for better user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->