### PR TITLE
chore(openapi-codegen): silence unused metadata field warnings

### DIFF
--- a/crates/openapi-codegen/src/parse.rs
+++ b/crates/openapi-codegen/src/parse.rs
@@ -58,7 +58,9 @@ pub struct Schema {
     pub any_of: Option<Vec<Schema>>,
     #[serde(default)]
     pub default: Option<serde_json::Value>,
+    #[allow(unused)]
     pub description: Option<String>,
+    #[allow(unused)]
     pub minimum: Option<f64>,
 }
 
@@ -228,7 +230,9 @@ pub struct Operation {
     pub request_body: Option<RequestBody>,
     pub responses: Option<IndexMap<String, Response>>,
     #[serde(default)]
+    #[allow(unused)]
     pub tags: Vec<String>,
+    #[allow(unused)]
     pub summary: Option<String>,
 }
 


### PR DESCRIPTION
## Summary
- Adds `#[allow(unused)]` to `Schema::{description, minimum}` and `Operation::{tags, summary}` in the OpenAPI parser.
- These fields are deserialized for spec completeness but the code generator does not consume them yet, so the compiler warns on every build.

## Test plan
- [ ] `moon :typecheck` passes cleanly without the prior dead-code warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)