### PR TITLE
Persist user space sidebar ordering to server

### DIFF
--- a/apps/client/docs/PROD-BACKEND-DEV.md
+++ b/apps/client/docs/PROD-BACKEND-DEV.md
@@ -39,7 +39,7 @@ Three things make this work:
    `/__api` / `/__media` prefix.
 2. **`server.proxy` in `vite.config.ts`** rewrites those prefixes away
    and forwards to the prod origins, with `changeOrigin: true`, `secure:
-   true`, and `ws: true` so WebSocket upgrades (main socket +
+true`, and `ws: true` so WebSocket upgrades (main socket +
    `y-websocket` collab) pass through.
 3. **`dev.prod-backend` moon task** (declared in `apps/client/moon.yml`)
    runs `vite --mode prod-backend` so Vite picks up the env file.

--- a/apps/client/public/sw.js
+++ b/apps/client/public/sw.js
@@ -1,4 +1,3 @@
- 
 // Mikoto push-only service worker.
 //
 // Deliberately has NO `fetch` handler — this SW never intercepts network

--- a/apps/client/src/components/sidebars/SpaceSidebar/Tooltip.tsx
+++ b/apps/client/src/components/sidebars/SpaceSidebar/Tooltip.tsx
@@ -4,7 +4,6 @@ export function SpaceIconTooltip({
   children,
   tooltip,
 }: {
-   
   children: React.ReactElement<any>;
   tooltip: string;
 }) {

--- a/apps/client/src/components/sidebars/SpaceSidebar/index.tsx
+++ b/apps/client/src/components/sidebars/SpaceSidebar/index.tsx
@@ -1,6 +1,6 @@
 import { Separator } from '@chakra-ui/react';
 import { DragDropProvider } from '@dnd-kit/react';
-import { useSortable } from '@dnd-kit/react/sortable';
+import { isSortable, useSortable } from '@dnd-kit/react/sortable';
 import styled from '@emotion/styled';
 import { faCirclePlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -186,12 +186,13 @@ export function SpaceSidebar() {
   return (
     <DragDropProvider
       onDragEnd={(event) => {
-        const { source, target } = event.operation;
-        if (!source || !target) return;
+        if (event.canceled) return;
+        const { source } = event.operation;
+        if (!isSortable(source)) return;
 
-        const fromIndex = spaceArray.findIndex((s) => s.id === source.id);
-        const toIndex = spaceArray.findIndex((s) => s.id === target.id);
-        if (fromIndex === -1 || toIndex === -1 || fromIndex === toIndex) return;
+        const fromIndex = source.sortable.initialIndex;
+        const toIndex = source.sortable.index;
+        if (fromIndex === toIndex) return;
 
         const reordered = reorder(
           spaceArray.map((s) => s.id),

--- a/apps/client/src/components/sidebars/SpaceSidebar/index.tsx
+++ b/apps/client/src/components/sidebars/SpaceSidebar/index.tsx
@@ -174,9 +174,8 @@ export function SpaceSidebar() {
   useSnapshot(mikoto.spaces);
   const contextMenu = useContextMenu(() => <SpaceBackContextMenu />);
 
-  const [order, setOrder] = useState<string[]>(() =>
-    // TODO: persist to server
-    JSON.parse(localStorage.getItem('spaceOrder') ?? '[]'),
+  const [order, setOrder] = useState<string[]>(
+    () => mikoto.user.me?.spaceOrder ?? [],
   );
   const [spaceArray, isOrdered] = orderSpaces(mikoto, order);
   if (!isOrdered) {
@@ -194,11 +193,16 @@ export function SpaceSidebar() {
         const toIndex = spaceArray.findIndex((s) => s.id === target.id);
         if (fromIndex === -1 || toIndex === -1 || fromIndex === toIndex) return;
 
-        setOrder((spaceOrders) => {
-          const reordered = reorder(spaceOrders, fromIndex, toIndex);
-          localStorage.setItem('spaceOrder', JSON.stringify(reordered));
-          return reordered;
-        });
+        const reordered = reorder(
+          spaceArray.map((s) => s.id),
+          fromIndex,
+          toIndex,
+        );
+        setOrder(reordered);
+        if (mikoto.user.me) {
+          mikoto.user.me.spaceOrder = reordered;
+        }
+        void mikoto.rest['user.update']({ spaceOrder: reordered }, {});
       }}
     >
       <StyledSpaceSidebar onContextMenu={contextMenu}>

--- a/apps/client/src/components/surfaces/Documents/plugins/FloatingToolbarPlugin.tsx
+++ b/apps/client/src/components/surfaces/Documents/plugins/FloatingToolbarPlugin.tsx
@@ -260,4 +260,3 @@ export function FloatingToolbarPlugin() {
 
   return <FloatingToolbar editor={editor} />;
 }
-

--- a/apps/client/src/components/surfaces/Messages/Message/index.tsx
+++ b/apps/client/src/components/surfaces/Messages/Message/index.tsx
@@ -216,4 +216,3 @@ export const MessageItem = ({ message, isSimple }: MessageProps) => {
     </MessageContainer>
   );
 };
-

--- a/apps/client/src/store/surface.ts
+++ b/apps/client/src/store/surface.ts
@@ -113,4 +113,3 @@ export function useTabs() {
 export function useActiveTabId() {
   return useAtomValue(activeTabIdState);
 }
-

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
 import { visualizer } from 'rollup-plugin-visualizer';
-import { defineConfig, loadEnv, type ProxyOptions } from 'vite';
+import { type ProxyOptions, defineConfig, loadEnv } from 'vite';
 
 // import { VitePWA } from 'vite-plugin-pwa';
 

--- a/apps/superego/api.json
+++ b/apps/superego/api.json
@@ -3762,6 +3762,17 @@
           },
           "name": {
             "type": "string"
+          },
+          "spaceOrder": {
+            "description": "Persisted ordering of the user's spaces in the sidebar. Always present on responses; optional in the schema so the base `User` shape remains structurally assignable to `UserExt`.",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         }
       },
@@ -3785,6 +3796,16 @@
               "string",
               "null"
             ]
+          },
+          "spaceOrder": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         }
       },

--- a/apps/superego/migrations/20260519151643_add_user_space_order.sql
+++ b/apps/superego/migrations/20260519151643_add_user_space_order.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" ADD COLUMN "spaceOrder" uuid[] NOT NULL DEFAULT '{}';

--- a/apps/superego/schema.sql
+++ b/apps/superego/schema.sql
@@ -405,7 +405,8 @@ CREATE TABLE public."User" (
     name character varying(64) NOT NULL,
     avatar character varying(256),
     description character varying(2048),
-    category public."UserCategory"
+    category public."UserCategory",
+    "spaceOrder" uuid[] DEFAULT '{}'::uuid[] NOT NULL
 );
 
 

--- a/apps/superego/src/entities/member.rs
+++ b/apps/superego/src/entities/member.rs
@@ -188,6 +188,7 @@ impl MemberExt {
                         .unwrap_or_else(|| UserExt {
                             base: User::ghost(),
                             handle: None,
+                            space_order: None,
                         }),
                     role_ids: role_ids
                         .get(&member_id)

--- a/apps/superego/src/entities/user.rs
+++ b/apps/superego/src/entities/user.rs
@@ -22,6 +22,11 @@ entity!(
         pub avatar: Option<String>,
         pub description: Option<String>,
         pub category: Option<UserCategory>,
+        /// Persisted ordering of the user's spaces in the sidebar.
+        /// Exposed via `UserExt`, not the base `User` shape.
+        #[serde(skip)]
+        #[schemars(skip)]
+        pub space_order: Vec<Uuid>,
     }
 );
 
@@ -245,6 +250,7 @@ impl RelationshipExt {
                     .unwrap_or_else(|| UserExt {
                         base: User::ghost(),
                         handle: None,
+                        space_order: None,
                     });
                 Self { base: rel, user }
             })
@@ -260,6 +266,10 @@ pub struct UserExt {
     pub base: User,
     /// The user's handle (if claimed)
     pub handle: Option<String>,
+    /// Persisted ordering of the user's spaces in the sidebar.
+    /// Always present on responses; optional in the schema so the base
+    /// `User` shape remains structurally assignable to `UserExt`.
+    pub space_order: Option<Vec<Uuid>>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -268,6 +278,7 @@ pub struct UserPatch {
     pub name: Option<String>,
     pub avatar: Option<String>,
     pub description: Option<String>,
+    pub space_order: Option<Vec<Uuid>>,
 }
 
 impl User {
@@ -278,6 +289,7 @@ impl User {
             avatar: None,
             description: None,
             category: None,
+            space_order: Vec::new(),
         }
     }
 
@@ -309,7 +321,8 @@ impl User {
             SET
             "name" = COALESCE($2, "name"),
             "avatar" = COALESCE($3, "avatar"),
-            "description" = COALESCE($4, "description")
+            "description" = COALESCE($4, "description"),
+            "spaceOrder" = COALESCE($5, "spaceOrder")
             WHERE "id" = $1
             RETURNING *
             "##,
@@ -318,6 +331,7 @@ impl User {
         .bind(patch.name)
         .bind(patch.avatar)
         .bind(patch.description)
+        .bind(patch.space_order)
         .fetch_optional(db)
         .await?
         .ok_or(Error::NotFound)?;
@@ -330,6 +344,7 @@ impl UserExt {
         let handle = Handle::for_user(user.id, db).await?;
         Ok(Self {
             handle: handle.map(|h| h.handle),
+            space_order: Some(user.space_order.clone()),
             base: user,
         })
     }
@@ -345,7 +360,12 @@ impl UserExt {
             .into_iter()
             .map(|user| {
                 let handle = handles.get(&user.id).cloned();
-                Self { handle, base: user }
+                let space_order = Some(user.space_order.clone());
+                Self {
+                    handle,
+                    space_order,
+                    base: user,
+                }
             })
             .collect())
     }

--- a/apps/superego/src/routes/bots.rs
+++ b/apps/superego/src/routes/bots.rs
@@ -206,6 +206,7 @@ async fn update_bot(
                 name: body.name.clone(),
                 avatar: body.avatar.clone(),
                 description: body.description.clone(),
+                space_order: None,
             },
             db(),
         )

--- a/crates/mikoto-client/src/generated.rs
+++ b/crates/mikoto-client/src/generated.rs
@@ -602,6 +602,7 @@ pub enum UserCategory {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UserExt {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
@@ -613,9 +614,12 @@ pub struct UserExt {
     pub handle: Option<String>,
     pub id: Uuid,
     pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub space_order: Option<Vec<Uuid>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UserPatch {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
@@ -623,6 +627,8 @@ pub struct UserPatch {
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub space_order: Option<Vec<Uuid>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1004,6 +1010,23 @@ impl<'a> HttpApi<'a> {
         req = req.json(body);
         let resp = req.send().await?.error_for_status()?;
         Ok(resp.json().await?)
+    }
+
+    pub async fn dm_unreads(&self) -> Result<Vec<ChannelUnread>, ClientError> {
+        let path = "/dm/unreads".to_string();
+        let mut req = self.client.get(self.url(&path))
+            .bearer_auth(self.token);
+        let resp = req.send().await?.error_for_status()?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn dm_acknowledge(&self, channel_id: Uuid) -> Result<(), ClientError> {
+        let path = format!("/dm/{}/ack", channel_id);
+        let mut req = self.client.post(self.url(&path))
+            .bearer_auth(self.token);
+        let resp = req.send().await?.error_for_status()?;
+        let _ = resp.text().await?;
+        Ok(())
     }
 
     pub async fn push_config(&self) -> Result<PushConfig, ClientError> {

--- a/packages/mikoto.js/src/api.gen.ts
+++ b/packages/mikoto.js/src/api.gen.ts
@@ -56,6 +56,7 @@ export const UserExt = z.object({
   handle: z.union([z.string(), z.null()]).optional(),
   id: z.string().uuid(),
   name: z.string(),
+  spaceOrder: z.union([z.array(z.string().uuid()), z.null()]).optional(),
 });
 export type UserExt = z.infer<typeof UserExt>;
 
@@ -138,6 +139,7 @@ export const UserPatch = z
     avatar: z.union([z.string(), z.null()]),
     description: z.union([z.string(), z.null()]),
     name: z.union([z.string(), z.null()]),
+    spaceOrder: z.union([z.array(z.string().uuid()), z.null()]),
   })
   .partial();
 export type UserPatch = z.infer<typeof UserPatch>;


### PR DESCRIPTION
## Summary

This PR adds server-side persistence for the user's space sidebar ordering, replacing the previous localStorage-only approach. The space order is now stored in the database and synced with the server when users reorder their spaces.

## Key Changes

- **Database Schema**: Added `spaceOrder` column to the `User` table as a UUID array with empty array default
- **Backend Models**: 
  - Added `space_order` field to `User` entity (persisted, excluded from base serialization)
  - Added `space_order` field to `UserExt` struct (exposed in API responses)
  - Added `space_order` to `UserPatch` for PATCH request handling
  - Updated user update query to handle space order changes
- **API Layer**: Updated `UserExt::from_user()` and `UserExt::from_users()` to populate space order from database
- **Frontend**: 
  - Changed space order initialization from localStorage to `mikoto.user.me?.spaceOrder`
  - Updated drag-and-drop handler to call `user.update()` API endpoint instead of localStorage
  - Optimistically update local state and sync with server
- **Generated Code**: Updated TypeScript API types to include `spaceOrder` field in `UserExt` and `UserPatch`
- **Migration**: Added migration to add the `spaceOrder` column to existing databases

## Implementation Details

- The `space_order` field is marked with `#[serde(skip)]` and `#[schemars(skip)]` on the base `User` entity to keep it internal, only exposed through `UserExt`
- The field is optional in `UserExt` schema to maintain structural assignability while always being present in actual responses
- Space reordering now triggers an immediate API call to persist changes server-side

https://claude.ai/code/session_01EASgg4ULgg9xQnzhDKoEKD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Your space sidebar ordering now persists across all devices and sessions. Once you arrange your spaces in your preferred order, the arrangement is automatically saved and maintained whenever you log in from any device, providing a consistent experience. Drag-and-drop reordering updates are instantly saved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mikotoIO/mikoto/pull/756?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->